### PR TITLE
fix: 유튜브 영상 길이 + 숏/롱폼 상태도 DB에 저장 하도록 로직 수정

### DIFF
--- a/news-youtube-service/src/main/java/com/example/devnote/news_youtube_service/dto/ContentMessageDto.java
+++ b/news-youtube-service/src/main/java/com/example/devnote/news_youtube_service/dto/ContentMessageDto.java
@@ -25,6 +25,8 @@ public class ContentMessageDto {
 
     // 유튜브
     private String channelTitle;        // 유튜브 채널명
-    private String channelThumbanilUrl; // 채널 썸네일
+    private String channelThumbnailUrl; // 채널 썸네일
     private Long viewCount;             // 영상 조회수
+    private Long durationSeconds;       // 영상 길이(초)
+    private String videoForm;           // "SHORTS" or "LONGFORM"
 }

--- a/processor-service/src/main/java/com/example/devnote/processor_service/dto/ContentDto.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/dto/ContentDto.java
@@ -26,4 +26,6 @@ public class ContentDto {
     private String channelTitle;        // 유튜브 채널명
     private String channelThumbnailUrl; // 채널 썸네일
     private Long viewCount;             // 영상 조회수
+    private Long durationSeconds;       // 영상 길이(초)
+    private String videoForm;           // "SHORTS" or "LONGFORM"
 }

--- a/processor-service/src/main/java/com/example/devnote/processor_service/dto/ContentMessageDto.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/dto/ContentMessageDto.java
@@ -22,6 +22,8 @@ public class ContentMessageDto {
 
     // 유튜브
     private String channelTitle;        // 유튜브 채널명
-    private String channelThumbanilUrl; // 채널 썸네일
+    private String channelThumbnailUrl; // 채널 썸네일
     private Long viewCount;             // 영상 조회수
+    private Long durationSeconds;       // 영상 길이(초)
+    private String videoForm;           // "SHORTS" or "LONGFORM"
 }

--- a/processor-service/src/main/java/com/example/devnote/processor_service/entity/ContentEntity.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/entity/ContentEntity.java
@@ -35,8 +35,11 @@ public class ContentEntity {
     @Column(length = 512)
     private String channelThumbnailUrl;
 
-    private Long viewCount;
+    @Column(length = 20)
+    private String videoForm;
 
+    private Long viewCount;
+    private Long durationSeconds;
     private String thumbnailUrl;
     private Instant publishedAt;
     private Instant createdAt;

--- a/processor-service/src/main/java/com/example/devnote/processor_service/service/ContentService.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/service/ContentService.java
@@ -59,8 +59,10 @@ public class ContentService {
                     .description(msg.getDescription())
                     .publishedAt(msg.getPublishedAt())
                     .channelTitle(msg.getChannelTitle())
-                    .channelThumbnailUrl(msg.getChannelThumbanilUrl())
+                    .channelThumbnailUrl(msg.getChannelThumbnailUrl())
                     .viewCount(msg.getViewCount())
+                    .durationSeconds(msg.getDurationSeconds())
+                    .videoForm(msg.getVideoForm())
                     .build();
             ent = contentRepository.save(ent);
             log.info("Saved ContentEntity id={}", ent.getId());
@@ -165,6 +167,8 @@ public class ContentService {
                 .channelTitle(e.getChannelTitle())
                 .channelThumbnailUrl(e.getChannelThumbnailUrl())
                 .viewCount(e.getViewCount())
+                .durationSeconds(e.getDurationSeconds())
+                .videoForm(e.getVideoForm())
                 .createdAt(e.getCreatedAt())
                 .build();
     }


### PR DESCRIPTION
영상길이와 숏/롱폼 상태도 DB에 저장합니다