### PR TITLE
feat: 채널, 콘텐츠 삭제시 유저의 찜 목록에서도 제거하는 로직 추가(kafka 사용)

### DIFF
--- a/news-youtube-service/src/main/java/com/example/devnote/news_youtube_service/config/KafkaProducerConfig.java
+++ b/news-youtube-service/src/main/java/com/example/devnote/news_youtube_service/config/KafkaProducerConfig.java
@@ -19,6 +19,7 @@ import java.util.Map;
 @Configuration
 public class KafkaProducerConfig {
     public static final String TOPIC_RAW_CONTENT = "raw.content";
+    public static final String TOPIC_CHANNEL_DELETED = "channel.deleted";
 
     /**
      * ProducerFactory 빈 생성

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	// Eureka Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
+	// Kafka 소비용
+	implementation 'org.springframework.kafka:spring-kafka'
+
 	// Webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 

--- a/user-service/src/main/java/com/example/devnote/UserServiceApplication.java
+++ b/user-service/src/main/java/com/example/devnote/UserServiceApplication.java
@@ -3,9 +3,11 @@ package com.example.devnote;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.kafka.annotation.EnableKafka;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableKafka
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/user-service/src/main/java/com/example/devnote/config/KafkaConsumerConfig.java
+++ b/user-service/src/main/java/com/example/devnote/config/KafkaConsumerConfig.java
@@ -1,0 +1,44 @@
+package com.example.devnote.config;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+@RequiredArgsConstructor
+public class KafkaConsumerConfig {
+    private final KafkaProperties props;
+
+    /**
+     * 삭제 이벤트용 ConsumerFactory (key/value 모두 String)
+     */
+    @Bean
+    public ConsumerFactory<String, String> deletionConsumerFactory() {
+        Map<String, Object> cfg = new HashMap<>(props.buildConsumerProperties());
+        cfg.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        cfg.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(cfg, new StringDeserializer(), new StringDeserializer());
+    }
+
+    /**
+     * 삭제 이벤트 전용 KafkaListenerContainerFactory 등록
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> deletionKafkaListenerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(deletionConsumerFactory());
+        return factory;
+    }
+}

--- a/user-service/src/main/java/com/example/devnote/repository/FavoriteChannelRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/FavoriteChannelRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface FavoriteChannelRepository extends JpaRepository<FavoriteChannel, Long> {
     Optional<FavoriteChannel> findByUserIdAndChannelSubscriptionId(Long userId, Long chSubId);
     List<FavoriteChannel> findByUserId(Long userId);
+    void deleteByChannelSubscriptionId(Long channelSubscriptionId);
 }

--- a/user-service/src/main/java/com/example/devnote/repository/FavoriteContentRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/FavoriteContentRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface FavoriteContentRepository extends JpaRepository<FavoriteContent, Long> {
     Optional<FavoriteContent> findByUserIdAndContentId(Long userId, Long contentId);
     List<FavoriteContent> findByUserId(Long userId);
+    void deleteByContentId(Long contentId);
 }

--- a/user-service/src/main/java/com/example/devnote/service/DeletionEventListener.java
+++ b/user-service/src/main/java/com/example/devnote/service/DeletionEventListener.java
@@ -1,0 +1,45 @@
+package com.example.devnote.service;
+
+import com.example.devnote.repository.FavoriteChannelRepository;
+import com.example.devnote.repository.FavoriteContentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DeletionEventListener {
+    private final FavoriteChannelRepository channelFavRepo;
+    private final FavoriteContentRepository contentFavRepo;
+
+    /**
+     * channel.deleted 토픽 수신 → 해당 채널 즐겨찾기 삭제
+     */
+    @KafkaListener(
+            topics = "channel.deleted",
+            containerFactory = "deletionKafkaListenerFactory"
+    )
+    @Transactional
+    public void onChannelDeleted(String channelIdStr) {
+        Long channelId = Long.parseLong(channelIdStr);
+        channelFavRepo.deleteByChannelSubscriptionId(channelId);
+        log.info("Deleted {} channel favorites", channelId);
+    }
+
+    /**
+     * content.deleted 토픽 수신 → 해당 콘텐츠 즐겨찾기 삭제
+     */
+    @KafkaListener(
+            topics = "content.deleted",
+            containerFactory = "deletionKafkaListenerFactory"
+    )
+    @Transactional
+    public void onContentDeleted(String contentIdStr) {
+        Long contentId = Long.parseLong(contentIdStr);
+        contentFavRepo.deleteByContentId(contentId);
+        log.info("Deleted {} content favorites", contentId);
+    }
+}


### PR DESCRIPTION
유저의 찜목록과 실제 존재하는 영상, 뉴스, 채널과 동기화를 위해 아이템 삭제시 kafka로 삭제를 요청하도록 로직을 추가했습니다