### PR TITLE
feat: 댓글 일괄조회 로직 추가

### DIFF
--- a/user-service/src/main/java/com/example/devnote/controller/CommentController.java
+++ b/user-service/src/main/java/com/example/devnote/controller/CommentController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/comments")
@@ -79,5 +80,20 @@ public class CommentController {
                 .data(null)
                 .build();
         return ResponseEntity.ok(body);
+    }
+
+    /** 여러 콘텐츠의 댓글 수를 일괄 조회 */
+    @GetMapping("/counts")
+    public ResponseEntity<ApiResponseDto<Map<Long, Integer>>> getCommentCounts(
+            @RequestParam List<Long> contentIds
+    ) {
+        Map<Long, Integer> counts = commentService.getCommentCounts(contentIds);
+        return ResponseEntity.ok(
+                ApiResponseDto.<Map<Long, Integer>>builder()
+                        .message("Fetched comment counts")
+                        .statusCode(HttpStatus.OK.value())
+                        .data(counts)
+                        .build()
+        );
     }
 }


### PR DESCRIPTION
기존에는 댓글개수를 구할때 각각 콘텐츠ID로 조회했습니다.
이제는 콘텐츠ID를 전부 수집후 한번에 요청을 하고 응답하도록 수정했습니다.

현재 페이지당 24개의 콘텐츠를 가져오는데 이때 화면측에서 댓글수를 가져오기 위해 서버에 24번을 호출했습니다.
현재는 1번 호출로 일괄적으로 처리하도록 수정했습니다.