### PR TITLE
fix: 댓글 삭제시 답글 확인 로직 추가 (답글 존재시 소프트 삭제, 미존재시 하드 삭제)

### DIFF
--- a/user-service/src/main/java/com/example/devnote/entity/CommentEntity.java
+++ b/user-service/src/main/java/com/example/devnote/entity/CommentEntity.java
@@ -8,7 +8,10 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.Instant;
 
 @Entity
-@Table(name = "comments")
+@Table(name = "comments", indexes = {
+        @Index(name = "idx_comments_content_parent_created", columnList = "contentId,parentId,createdAt"),
+        @Index(name = "idx_comments_user", columnList = "userId")
+})
 @Getter
 @Setter
 @NoArgsConstructor
@@ -38,8 +41,17 @@ public class CommentEntity {
     private String passwordHash;
 
     /** 댓글 본문 */
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT")
     private String content;
+
+    /**
+     * 소프트 삭제 여부
+     * - true: 내용만 삭제, 나머지 정보는 유지
+     * - false: 일반 댓글
+     */
+    @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
+    private boolean deleted = false;
 
     @CreationTimestamp
     private Instant createdAt;

--- a/user-service/src/main/java/com/example/devnote/repository/CommentRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/CommentRepository.java
@@ -13,6 +13,9 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
     List<CommentEntity> findByParentIdOrderByCreatedAtAsc(Long parentId);
     List<CommentEntity> findByUserIdOrderByCreatedAtDesc(Long userId);
 
+    /** 특정 댓글의 자식 존재 여부 */
+    boolean existsByParentId(Long parentId);
+
     /** 특정 사용자가 작성한 총 댓글 수 (메인 댓글 + 대댓글) */
     @Query("SELECT COUNT(c) FROM CommentEntity c WHERE c.userId = :userId")
     int countTotalCommentsByUserId(@Param("userId") Long userId);


### PR DESCRIPTION
댓글에 대한 답글이 달려 있을때 본 댓글을 삭제한다면 본 댓글의 내용만 null처리 하고 DB에 남겨둡니다.
또한 답글이 달려있지 않으면 DB에서 제거합니다. 추가로 답글이 달려있지 않은 댓글을 제거한다면
부모 댓글의 댓글 제거 플래그를 확인 후 부모 댓글도 DB에서 제거합니다.

#34 