### PR TITLE
feat: 신규 생성된 콘텐츠 통계 로직 추가 (DB + Redis)

### DIFF
--- a/processor-service/src/main/java/com/example/devnote/processor_service/controller/InternalStatsController.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/controller/InternalStatsController.java
@@ -1,0 +1,31 @@
+package com.example.devnote.processor_service.controller;
+
+import com.example.devnote.processor_service.service.ContentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+/**
+ * 서비스 간 통신(내부용)을 위한 통계 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/stats")
+public class InternalStatsController {
+
+    private final ContentService contentService;
+
+    @GetMapping("/content/count-by-day")
+    public ResponseEntity<Map<String, Long>> getCountByDay(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        long count = contentService.countByDay(date);
+        return ResponseEntity.ok(Map.of("count", count));
+    }
+}

--- a/processor-service/src/main/java/com/example/devnote/processor_service/entity/ContentEntity.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/entity/ContentEntity.java
@@ -45,6 +45,7 @@ public class ContentEntity {
     private Long subscriberCount;
 
     @Column(name = "local_view_count", nullable = false)
+    @Builder.Default
     private Long localViewCount = 0L;
 
     private Long viewCount;

--- a/processor-service/src/main/java/com/example/devnote/processor_service/repository/ContentRepository.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/repository/ContentRepository.java
@@ -3,11 +3,16 @@ package com.example.devnote.processor_service.repository;
 import com.example.devnote.processor_service.entity.ContentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface ContentRepository extends JpaRepository<ContentEntity, Long>, JpaSpecificationExecutor<ContentEntity> {
     Optional<ContentEntity> findBySourceAndLink(String source, String link);
     List<ContentEntity> findBySourceAndCategory(String source, String category);
+    @Query("SELECT COUNT(c) FROM ContentEntity c WHERE FUNCTION('DATE', c.createdAt) = :date")
+    long countByCreatedAt(@Param("date") LocalDate date);
 }

--- a/processor-service/src/main/java/com/example/devnote/processor_service/service/CategoryClassificationService.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/service/CategoryClassificationService.java
@@ -26,22 +26,22 @@ public class CategoryClassificationService {
     /**
      * 1시간마다 YOUTUBE 영상목록중 카테고리가 TBC 인것을 조회해서 AI로 분류 후 업데이트
      */
-    @Scheduled(fixedDelayString = "3600000")
-    public void classifyTbcContents() {
-        List<ContentEntity> toClassify = contentRepository
-                .findBySourceAndCategory("YOUTUBE", "TBC");
-
-        toClassify.forEach(ent -> {
-            try {
-                String label = callGemini(ent.getTitle());
-                ent.setCategory(label);
-                contentRepository.save(ent);
-                log.info("Classified id={} title='{}' → {}", ent.getId(), ent.getTitle(), label);
-            } catch (Exception ex) {
-                log.warn("Failed to classify id={} title='{}'", ent.getId(), ent.getTitle(), ex);
-            }
-        });
-    }
+//    @Scheduled(fixedDelayString = "3600000")
+//    public void classifyTbcContents() {
+//        List<ContentEntity> toClassify = contentRepository
+//                .findBySourceAndCategory("YOUTUBE", "TBC");
+//
+//        toClassify.forEach(ent -> {
+//            try {
+//                String label = callGemini(ent.getTitle());
+//                ent.setCategory(label);
+//                contentRepository.save(ent);
+//                log.info("Classified id={} title='{}' → {}", ent.getId(), ent.getTitle(), label);
+//            } catch (Exception ex) {
+//                log.warn("Failed to classify id={} title='{}'", ent.getId(), ent.getTitle(), ex);
+//            }
+//        });
+//    }
 
     /**
      * Gemini 2.5 Flash 호출 후 카테고리 받아오기

--- a/stats-service/build.gradle
+++ b/stats-service/build.gradle
@@ -15,6 +15,7 @@ repositories {
 dependencies {
 	// Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	// Eureka Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
@@ -28,6 +29,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly   'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Kafka
+	implementation 'org.springframework.kafka:spring-kafka'
 
 	// Scheduling
 	implementation 'org.springframework.boot:spring-boot-starter'

--- a/stats-service/src/main/java/com/example/devnote/stats_service/config/KafkaConsumerConfig.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/config/KafkaConsumerConfig.java
@@ -1,0 +1,48 @@
+package com.example.devnote.stats_service.config;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Kafka Consumer 설정
+ */
+@Configuration
+@EnableKafka
+@RequiredArgsConstructor
+public class KafkaConsumerConfig {
+
+    private final KafkaProperties kafkaProperties;
+
+    /** ConsumerFactory 빈 생성 (String/String 타입 메시지용) */
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>(kafkaProperties.buildConsumerProperties());
+
+        // Key/Value Deserializer 설정
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    /**
+     * KafkaListenerContainerFactory 빈 생성
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/config/WebClientConfig.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/config/WebClientConfig.java
@@ -1,0 +1,15 @@
+package com.example.devnote.stats_service.config;
+
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    @LoadBalanced
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/controller/ContentStatsController.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/controller/ContentStatsController.java
@@ -1,0 +1,82 @@
+package com.example.devnote.stats_service.controller;
+
+import com.example.devnote.stats_service.dto.ApiResponseDto;
+import com.example.devnote.stats_service.dto.DailyCountDto;
+import com.example.devnote.stats_service.dto.MonthlyCountDto;
+import com.example.devnote.stats_service.dto.YearlyCountDto;
+import com.example.devnote.stats_service.service.ContentStatsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 신규 콘텐츠 생성 통계 API 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stats/content")
+public class ContentStatsController {
+
+    private final ContentStatsService service;
+
+    /** 기간별 일일 신규 콘텐츠 수 조회 */
+    @GetMapping("/daily")
+    public ResponseEntity<ApiResponseDto<List<DailyCountDto>>> getDaily(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+        List<DailyCountDto> data = service.getDailyStats(start, end);
+        return ResponseEntity.ok(ApiResponseDto.<List<DailyCountDto>>builder()
+                .message("Daily new content stats")
+                .statusCode(200)
+                .data(data)
+                .build());
+    }
+
+    /** 특정 연도의 월별 신규 콘텐츠 수 조회 */
+    @GetMapping("/monthly")
+    public ResponseEntity<ApiResponseDto<List<MonthlyCountDto>>> getMonthly(
+            @RequestParam int year) {
+        List<MonthlyCountDto> data = service.getMonthlyStats(year);
+        return ResponseEntity.ok(ApiResponseDto.<List<MonthlyCountDto>>builder()
+                .message("Monthly new content stats for " + year)
+                .statusCode(200)
+                .data(data)
+                .build());
+    }
+
+    /** 기간별 연간 신규 콘텐츠 수 조회 */
+    @GetMapping("/yearly")
+    public ResponseEntity<ApiResponseDto<List<YearlyCountDto>>> getYearly(
+            @RequestParam int startYear,
+            @RequestParam int endYear) {
+        List<YearlyCountDto> data = service.getYearlyStats(startYear, endYear);
+        return ResponseEntity.ok(ApiResponseDto.<List<YearlyCountDto>>builder()
+                .message("Yearly new content stats")
+                .statusCode(200)
+                .data(data)
+                .build());
+    }
+
+    /**
+     * 지정된 기간의 신규 콘텐츠 통계를 재처리
+     * ** 추후 권한 부여 필요 (관리자용)
+     */
+    @PostMapping("/backfill")
+    public ResponseEntity<ApiResponseDto<String>> backfill(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+
+        service.backfillHistoricalStats(start, end);
+
+        String message = String.format("Backfill for new content stats from %s to %s has been triggered.", start, end);
+        return ResponseEntity.ok(ApiResponseDto.<String>builder()
+                .message(message)
+                .statusCode(200)
+                .data(null)
+                .build());
+    }
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/MonthlyCountDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/MonthlyCountDto.java
@@ -1,0 +1,15 @@
+package com.example.devnote.stats_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MonthlyCountDto {
+    private int month; // 1..12
+    private long count;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/YearlyCountDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/YearlyCountDto.java
@@ -1,0 +1,15 @@
+package com.example.devnote.stats_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class YearlyCountDto {
+    private int year;
+    private long count;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/entity/ContentDailyStats.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/entity/ContentDailyStats.java
@@ -1,0 +1,29 @@
+package com.example.devnote.stats_service.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "content_daily_stats",
+        uniqueConstraints = @UniqueConstraint(name = "uk_content_stats_day", columnNames = {"day"}),
+        indexes = @Index(name = "idx_content_stats_day", columnList = "day"))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ContentDailyStats {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 통계 기준일 */
+    @Column(nullable = false)
+    private LocalDate day;
+
+    /** 해당 일의 신규 콘텐츠 수 */
+    @Column(nullable = false)
+    private long count;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/repository/ContentDailyStatsRepository.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/repository/ContentDailyStatsRepository.java
@@ -1,0 +1,35 @@
+package com.example.devnote.stats_service.repository;
+
+import com.example.devnote.stats_service.entity.ContentDailyStats;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface ContentDailyStatsRepository extends JpaRepository<ContentDailyStats, Long> {
+
+    /** 기간 내 일별 데이터 조회 */
+    @Query("SELECT c.day as day, c.count as count FROM ContentDailyStats c WHERE c.day BETWEEN :start AND :end ORDER BY c.day ASC")
+    List<Object[]> findDailyCountsByRange(@Param("start") LocalDate start, @Param("end") LocalDate end);
+
+    /** 특정 연도의 월별 합계 조회 */
+    @Query("SELECT FUNCTION('MONTH', c.day) as month, SUM(c.count) as count " +
+            "FROM ContentDailyStats c " +
+            "WHERE FUNCTION('YEAR', c.day) = :year " +
+            "GROUP BY FUNCTION('MONTH', c.day) " +
+            "ORDER BY FUNCTION('MONTH', c.day) ASC")
+    List<Object[]> findMonthlyCountsByYear(@Param("year") int year);
+
+    /** 기간 내 연도별 합계 조회 */
+    @Query("SELECT FUNCTION('YEAR', c.day) as year, SUM(c.count) as count " +
+            "FROM ContentDailyStats c " +
+            "WHERE FUNCTION('YEAR', c.day) BETWEEN :startYear AND :endYear " +
+            "GROUP BY FUNCTION('YEAR', c.day) " +
+            "ORDER BY FUNCTION('YEAR', c.day) ASC")
+    List<Object[]> findYearlyCountsByRange(@Param("startYear") int startYear, @Param("endYear") int endYear);
+
+    Optional<ContentDailyStats> findByDay(LocalDate day);
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/service/ContentStatsService.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/service/ContentStatsService.java
@@ -1,0 +1,200 @@
+package com.example.devnote.stats_service.service;
+
+
+import com.example.devnote.stats_service.dto.DailyCountDto;
+import com.example.devnote.stats_service.dto.MonthlyCountDto;
+import com.example.devnote.stats_service.dto.YearlyCountDto;
+import com.example.devnote.stats_service.entity.ContentDailyStats;
+import com.example.devnote.stats_service.repository.ContentDailyStatsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 신규 콘텐츠 생성 통계 서비스
+ * - Kafka로 생성 이벤트를 받아 Redis에 실시간 카운트
+ * - 매일 자정 스케줄러로 Redis 카운트를 DB에 영속화
+ * - 일/월/연 단위 조회 API 제공
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ContentStatsService {
+
+    private final StringRedisTemplate redis;
+    private final ContentDailyStatsRepository repo;
+    private final WebClient.Builder webClientBuilder;
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+    private static final String TOPIC_CONTENT_CREATED = "content.created";
+
+    // Redis 키 포맷
+    private String dayCountKey(LocalDate day) {
+        return "stats:content:new:day:" + day.format(DateTimeFormatter.BASIC_ISO_DATE);
+    }
+
+    /**
+     * Kafka 'content.created' 토픽 리스너
+     * - 메시지 수신 시 오늘 날짜의 신규 콘텐츠 카운터를 Redis에서 1 증가시킴
+     */
+    @KafkaListener(topics = TOPIC_CONTENT_CREATED, groupId = "stats-service-group-content")
+    public void onContentCreated(String message) {
+        // 메시지 내용은 현재 사용하지 않지만, 추후 확장을 위해 받을 수 있음
+        LocalDate today = LocalDate.now(ZONE);
+        String key = dayCountKey(today);
+        log.debug("Incrementing new content count for key: {}", key);
+        redis.opsForValue().increment(key);
+        // 키가 새로 생성된 경우 TTL 설정 (2일)
+        redis.expire(key, Duration.ofDays(2));
+    }
+
+    /**
+     * 매일 자정에 어제 날짜의 Redis 카운트를 DB에 저장 (스케줄링)
+     */
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void flushYesterdayStatsToDb() {
+        LocalDate yesterday = LocalDate.now(ZONE).minusDays(1);
+        flushStatsToDbForDate(yesterday);
+    }
+
+    /**
+     * 특정 날짜의 Redis 카운트를 DB에 저장/업데이트하는 메서드
+     * @param dateToFlush 통계를 DB에 저장할 날짜
+     */
+    @Transactional
+    public void flushStatsToDbForDate(LocalDate dateToFlush) {
+        long count = 0;
+        try {
+            WebClient webClient = webClientBuilder.baseUrl("http://processor-service").build();
+            Map<String, Long> response = webClient.get()
+                    .uri("/internal/stats/content/count-by-day?date={date}", dateToFlush)
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<Map<String, Long>>() {})
+                    .block(); // 동기 방식으로 결과를 기다림
+
+            if (response != null && response.containsKey("count")) {
+                count = response.get("count");
+            }
+        } catch (Exception e) {
+            log.error("[STATS-CONTENT] Failed to fetch count from processor-service for date {}: {}", dateToFlush, e.getMessage());
+            // 에러 발생 시 0으로 처리
+            count = 0;
+        }
+
+        log.info("[STATS-CONTENT] Flushing date '{}' new content count ({}) to DB.", dateToFlush, count);
+
+        ContentDailyStats stats = repo.findByDay(dateToFlush)
+                .orElse(new ContentDailyStats(null, dateToFlush, 0L));
+        stats.setCount(count);
+        repo.save(stats);
+    }
+
+    /**
+     * 지정된 기간 동안의 통계를 Redis에서 읽어와 DB에 저장
+     * @param start 시작일
+     * @param end 종료일
+     */
+    public void backfillHistoricalStats(LocalDate start, LocalDate end) {
+        log.info("[STATS-CONTENT][BACKFILL] Starting backfill from {} to {}", start, end);
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            flushStatsToDbForDate(date);
+        }
+        log.info("[STATS-CONTENT][BACKFILL] Completed backfill.");
+    }
+
+    /**
+     * 오늘 신규 콘텐츠 수 (실시간)
+     */
+    private long getTodayCount() {
+        LocalDate today = LocalDate.now(ZONE);
+        String value = redis.opsForValue().get(dayCountKey(today));
+        return (value != null) ? Long.parseLong(value) : 0L;
+    }
+
+    /**
+     * 기간별 일별 신규 콘텐츠 수 조회
+     */
+    public List<DailyCountDto> getDailyStats(LocalDate start, LocalDate end) {
+        Map<LocalDate, Long> dbCounts = repo.findDailyCountsByRange(start, end).stream()
+                .collect(Collectors.toMap(
+                        row -> (LocalDate) row[0],
+                        row -> (long) row[1]
+                ));
+
+        List<DailyCountDto> result = new ArrayList<>();
+        LocalDate today = LocalDate.now(ZONE);
+
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            long count = date.equals(today)
+                    ? getTodayCount()
+                    : dbCounts.getOrDefault(date, 0L);
+
+            result.add(new DailyCountDto(date.format(DateTimeFormatter.ISO_LOCAL_DATE), count));
+        }
+        return result;
+    }
+
+    /**
+     * 특정 연도의 월별 신규 콘텐츠 수 조회
+     */
+    public List<MonthlyCountDto> getMonthlyStats(int year) {
+        Map<Integer, Long> dbCounts = repo.findMonthlyCountsByYear(year).stream()
+                .collect(Collectors.toMap(
+                        row -> ((Number) row[0]).intValue(),
+                        row -> (long) row[1]
+                ));
+
+        // 오늘의 데이터는 아직 DB에 없으므로, 현재 연도/월 데이터에 Redis 값을 합산
+        LocalDate today = LocalDate.now(ZONE);
+        if (today.getYear() == year) {
+            long todayCount = getTodayCount();
+            dbCounts.merge(today.getMonthValue(), todayCount, Long::sum);
+        }
+
+        List<MonthlyCountDto> result = new ArrayList<>();
+        for (int month = 1; month <= 12; month++) {
+            result.add(new MonthlyCountDto(month, dbCounts.getOrDefault(month, 0L)));
+        }
+        return result;
+    }
+
+    /**
+     * 기간별 연도별 신규 콘텐츠 수 조회
+     */
+    public List<YearlyCountDto> getYearlyStats(int startYear, int endYear) {
+        Map<Integer, Long> dbCounts = repo.findYearlyCountsByRange(startYear, endYear).stream()
+                .collect(Collectors.toMap(
+                        row -> ((Number) row[0]).intValue(),
+                        row -> (long) row[1]
+                ));
+
+        // 오늘의 데이터는 아직 DB에 없으므로, 현재 연도 데이터에 합산
+        LocalDate today = LocalDate.now(ZONE);
+        if (today.getYear() >= startYear && today.getYear() <= endYear) {
+            long todayCount = getTodayCount();
+            dbCounts.merge(today.getYear(), todayCount, Long::sum);
+        }
+
+        List<YearlyCountDto> result = new ArrayList<>();
+        for (int year = startYear; year <= endYear; year++) {
+            result.add(new YearlyCountDto(year, dbCounts.getOrDefault(year, 0L)));
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
신규 생성된 콘텐츠의 통계를 측정하기 위해 로직을 추가했습니다. 조회일이 포함되지않은 데이터는 DB조회, 조회일이 포함되어있다면 redis에서 실시간 조회를 사용합니다