### PR TITLE
feat: 신규 생성된 댓글 통계 로직 추가 (DB + Redis)

### DIFF
--- a/stats-service/src/main/java/com/example/devnote/stats_service/controller/CommentStatsController.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/controller/CommentStatsController.java
@@ -1,0 +1,78 @@
+package com.example.devnote.stats_service.controller;
+
+import com.example.devnote.stats_service.dto.ApiResponseDto;
+import com.example.devnote.stats_service.dto.DailyCountDto;
+import com.example.devnote.stats_service.dto.MonthlyCountDto;
+import com.example.devnote.stats_service.dto.YearlyCountDto;
+import com.example.devnote.stats_service.service.CommentStatsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 신규 댓글 생성 통계 API 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stats/comment")
+public class CommentStatsController {
+
+    private final CommentStatsService service;
+
+    /** 기간별 일일 신규 댓글 수 조회 */
+    @GetMapping("/daily")
+    public ResponseEntity<ApiResponseDto<List<DailyCountDto>>> getDaily(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+        List<DailyCountDto> data = service.getDailyStats(start, end);
+        return ResponseEntity.ok(ApiResponseDto.<List<DailyCountDto>>builder()
+                .message("Daily new comment stats")
+                .statusCode(200)
+                .data(data)
+                .build());
+    }
+
+    /** 특정 연도의 월별 신규 댓글 수 조회 */
+    @GetMapping("/monthly")
+    public ResponseEntity<ApiResponseDto<List<MonthlyCountDto>>> getMonthly(@RequestParam int year) {
+        List<MonthlyCountDto> data = service.getMonthlyStats(year);
+        return ResponseEntity.ok(ApiResponseDto.<List<MonthlyCountDto>>builder()
+                .message("Monthly new comment stats for " + year)
+                .statusCode(200)
+                .data(data)
+                .build());
+    }
+
+    /** 기간별 연간 신규 댓글 수 조회 */
+    @GetMapping("/yearly")
+    public ResponseEntity<ApiResponseDto<List<YearlyCountDto>>> getYearly(
+            @RequestParam int startYear, @RequestParam int endYear) {
+        List<YearlyCountDto> data = service.getYearlyStats(startYear, endYear);
+        return ResponseEntity.ok(ApiResponseDto.<List<YearlyCountDto>>builder()
+                .message("Yearly new comment stats")
+                .statusCode(200)
+                .data(data)
+                .build());
+    }
+
+    /**
+     * 지정된 기간의 신규 댓글 통계를 재처리
+     * ** 추후 권한 부여 필요 (관리자용)
+     */
+    @PostMapping("/backfill")
+    public ResponseEntity<ApiResponseDto<String>> backfill(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+        service.backfillHistoricalStats(start, end);
+        String message = String.format("Backfill for new comment stats from %s to %s has been triggered.", start, end);
+        return ResponseEntity.ok(ApiResponseDto.<String>builder()
+                .message(message)
+                .statusCode(200)
+                .data(null)
+                .build());
+    }
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/entity/CommentDailyStats.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/entity/CommentDailyStats.java
@@ -1,0 +1,29 @@
+package com.example.devnote.stats_service.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "comment_daily_stats",
+        uniqueConstraints = @UniqueConstraint(name = "uk_comment_stats_day", columnNames = {"day"}),
+        indexes = @Index(name = "idx_comment_stats_day", columnList = "day"))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentDailyStats {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 통계 기준일 */
+    @Column(nullable = false)
+    private LocalDate day;
+
+    /** 해당 일의 신규 댓글 수 */
+    @Column(nullable = false)
+    private long count;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/repository/CommentDailyStatsRepository.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/repository/CommentDailyStatsRepository.java
@@ -1,0 +1,35 @@
+package com.example.devnote.stats_service.repository;
+
+import com.example.devnote.stats_service.entity.CommentDailyStats;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentDailyStatsRepository extends JpaRepository<CommentDailyStats, Long> {
+
+    /** 기간 내 일별 데이터 조회 */
+    @Query("SELECT c.day as day, c.count as count FROM CommentDailyStats c WHERE c.day BETWEEN :start AND :end ORDER BY c.day ASC")
+    List<Object[]> findDailyCountsByRange(@Param("start") LocalDate start, @Param("end") LocalDate end);
+
+    /** 특정 연도의 월별 합계 조회 */
+    @Query("SELECT FUNCTION('MONTH', c.day) as month, SUM(c.count) as count " +
+            "FROM CommentDailyStats c " +
+            "WHERE FUNCTION('YEAR', c.day) = :year " +
+            "GROUP BY FUNCTION('MONTH', c.day) " +
+            "ORDER BY FUNCTION('MONTH', c.day) ASC")
+    List<Object[]> findMonthlyCountsByYear(@Param("year") int year);
+
+    /** 기간 내 연도별 합계 조회 */
+    @Query("SELECT FUNCTION('YEAR', c.day) as year, SUM(c.count) as count " +
+            "FROM CommentDailyStats c " +
+            "WHERE FUNCTION('YEAR', c.day) BETWEEN :startYear AND :endYear " +
+            "GROUP BY FUNCTION('YEAR', c.day) " +
+            "ORDER BY FUNCTION('YEAR', c.day) ASC")
+    List<Object[]> findYearlyCountsByRange(@Param("startYear") int startYear, @Param("endYear") int endYear);
+
+    Optional<CommentDailyStats> findByDay(LocalDate day);
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/service/CommentStatsService.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/service/CommentStatsService.java
@@ -1,0 +1,171 @@
+package com.example.devnote.stats_service.service;
+
+import com.example.devnote.stats_service.dto.DailyCountDto;
+import com.example.devnote.stats_service.dto.MonthlyCountDto;
+import com.example.devnote.stats_service.dto.YearlyCountDto;
+import com.example.devnote.stats_service.entity.CommentDailyStats;
+import com.example.devnote.stats_service.repository.CommentDailyStatsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 신규 댓글 생성 통계 서비스
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CommentStatsService {
+
+    private final StringRedisTemplate redis;
+    private final CommentDailyStatsRepository repo;
+    private final WebClient.Builder webClientBuilder;
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+    private static final String TOPIC_COMMENT_CREATED = "comment.created";
+
+    // Redis 키 포맷
+    private String dayCountKey(LocalDate day) {
+        return "stats:comment:new:day:" + day.format(DateTimeFormatter.BASIC_ISO_DATE);
+    }
+
+    /**
+     * Kafka 'comment.created' 토픽 리스너
+     * - 메시지 수신 시 오늘 날짜의 신규 댓글 카운터를 Redis에서 1 증가시킴
+     */
+    @KafkaListener(topics = TOPIC_COMMENT_CREATED, groupId = "stats-service-group-comment")
+    public void onCommentCreated(String message) {
+        LocalDate today = LocalDate.now(ZONE);
+        String key = dayCountKey(today);
+        log.debug("Incrementing new comment count for key: {}", key);
+        redis.opsForValue().increment(key);
+        redis.expire(key, Duration.ofDays(2));
+    }
+
+    /**
+     * 매일 자정에 어제 날짜의 Redis 카운트를 DB에 저장 (스케줄링)
+     */
+    @Scheduled(cron = "0 1 0 * * *", zone = "Asia/Seoul") // 콘텐츠 통계와 1분 차이
+    @Transactional
+    public void flushYesterdayStatsToDb() {
+        LocalDate yesterday = LocalDate.now(ZONE).minusDays(1);
+        flushStatsToDbForDate(yesterday);
+    }
+
+    /**
+     * 특정 날짜의 Redis 카운트를 DB에 저장/업데이트하는 메서드
+     * @param dateToFlush 통계를 DB에 저장할 날짜
+     */
+    @Transactional
+    public void flushStatsToDbForDate(LocalDate dateToFlush) {
+        long count = 0;
+        try {
+            WebClient webClient = webClientBuilder.baseUrl("http://user-service").build();
+            Map<String, Long> response = webClient.get()
+                    .uri("/internal/stats/comment/count-by-day?date={date}", dateToFlush)
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<Map<String, Long>>() {})
+                    .block();
+
+            if (response != null && response.containsKey("count")) {
+                count = response.get("count");
+            }
+        } catch (Exception e) {
+            log.error("[STATS-COMMENT] Failed to fetch count from user-service for date {}: {}", dateToFlush, e.getMessage());
+            count = 0;
+        }
+
+        log.info("[STATS-COMMENT] Flushing date '{}' new comment count ({}) to DB.", dateToFlush, count);
+
+        CommentDailyStats stats = repo.findByDay(dateToFlush)
+                .orElse(new CommentDailyStats(null, dateToFlush, 0L));
+        stats.setCount(count);
+        repo.save(stats);
+    }
+
+    /**
+     * 지정된 기간 동안의 통계를 Redis에서 읽어와 DB에 저장
+     * @param start 시작일
+     * @param end 종료일
+     */
+    public void backfillHistoricalStats(LocalDate start, LocalDate end) {
+        log.info("[STATS-COMMENT][BACKFILL] Starting backfill from {} to {}", start, end);
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            flushStatsToDbForDate(date);
+        }
+        log.info("[STATS-COMMENT][BACKFILL] Completed backfill.");
+    }
+
+    /**
+     * 오늘 신규 댓글 수 (실시간)
+     */
+    private long getTodayCount() {
+        LocalDate today = LocalDate.now(ZONE);
+        String value = redis.opsForValue().get(dayCountKey(today));
+        return (value != null) ? Long.parseLong(value) : 0L;
+    }
+
+    /**
+     * 기간별 일별 신규 댓글 수 조회
+     */
+    public List<DailyCountDto> getDailyStats(LocalDate start, LocalDate end) {
+        Map<LocalDate, Long> dbCounts = repo.findDailyCountsByRange(start, end).stream()
+                .collect(Collectors.toMap(row -> (LocalDate) row[0], row -> (long) row[1]));
+        List<DailyCountDto> result = new ArrayList<>();
+        LocalDate today = LocalDate.now(ZONE);
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            long count = date.equals(today) ? getTodayCount() : dbCounts.getOrDefault(date, 0L);
+            result.add(new DailyCountDto(date.format(DateTimeFormatter.ISO_LOCAL_DATE), count));
+        }
+        return result;
+    }
+
+    /**
+     * 특정 연도의 월별 신규 댓글 수 조회
+     */
+    public List<MonthlyCountDto> getMonthlyStats(int year) {
+        Map<Integer, Long> dbCounts = repo.findMonthlyCountsByYear(year).stream()
+                .collect(Collectors.toMap(row -> ((Number) row[0]).intValue(), row -> (long) row[1]));
+        LocalDate today = LocalDate.now(ZONE);
+        if (today.getYear() == year) {
+            dbCounts.merge(today.getMonthValue(), getTodayCount(), Long::sum);
+        }
+        List<MonthlyCountDto> result = new ArrayList<>();
+        for (int month = 1; month <= 12; month++) {
+            result.add(new MonthlyCountDto(month, dbCounts.getOrDefault(month, 0L)));
+        }
+        return result;
+    }
+
+    /**
+     * 기간별 연도별 신규 댓글 수 조회
+     */
+    public List<YearlyCountDto> getYearlyStats(int startYear, int endYear) {
+        Map<Integer, Long> dbCounts = repo.findYearlyCountsByRange(startYear, endYear).stream()
+                .collect(Collectors.toMap(row -> ((Number) row[0]).intValue(), row -> (long) row[1]));
+        LocalDate today = LocalDate.now(ZONE);
+        if (today.getYear() >= startYear && today.getYear() <= endYear) {
+            dbCounts.merge(today.getYear(), getTodayCount(), Long::sum);
+        }
+        List<YearlyCountDto> result = new ArrayList<>();
+        for (int year = startYear; year <= endYear; year++) {
+            result.add(new YearlyCountDto(year, dbCounts.getOrDefault(year, 0L)));
+        }
+        return result;
+    }
+}

--- a/user-service/src/main/java/com/example/devnote/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/example/devnote/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/oauth2/**", "/login/**", "/api/v1/auth/**", "/api/v1/comments/**")
+                        .requestMatchers("/oauth2/**", "/login/**", "/api/v1/auth/**", "/api/v1/comments/**", "/internal/**")
                         .permitAll()
                         .requestMatchers("/api/v1/users/*/profile").permitAll()
                         .anyRequest().authenticated()

--- a/user-service/src/main/java/com/example/devnote/controller/InternalStatsController.java
+++ b/user-service/src/main/java/com/example/devnote/controller/InternalStatsController.java
@@ -1,0 +1,31 @@
+package com.example.devnote.controller;
+
+import com.example.devnote.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+/**
+ * 서비스 간 통신(내부용)을 위한 통계 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/stats")
+public class InternalStatsController {
+
+    private final CommentService commentService;
+
+    @GetMapping("/comment/count-by-day")
+    public ResponseEntity<Map<String, Long>> getCommentCountByDay(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        long count = commentService.countByDay(date);
+        return ResponseEntity.ok(Map.of("count", count));
+    }
+}

--- a/user-service/src/main/java/com/example/devnote/repository/CommentRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/CommentRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
@@ -19,4 +20,8 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
     /** 특정 사용자가 작성한 총 댓글 수 (메인 댓글 + 대댓글) */
     @Query("SELECT COUNT(c) FROM CommentEntity c WHERE c.userId = :userId")
     int countTotalCommentsByUserId(@Param("userId") Long userId);
+
+    /** 특정 날짜에 생성된 총 댓글 수 (대댓글 포함) */
+    @Query("SELECT COUNT(c) FROM CommentEntity c WHERE FUNCTION('DATE', c.createdAt) = :date")
+    long countByCreatedAt(@Param("date") LocalDate date);
 }


### PR DESCRIPTION
신규 생성된 댓글의 통계를 측정하기 위해 로직을 추가했습니다. 조회일이 포함되지않은 데이터는 DB조회, 조회일이 포함되어있다면 redis에서 실시간 조회를 사용합니다