### PR TITLE
feat: 콘텐츠 조회수 통계 로직 추가 (DB + Redis)

### DIFF
--- a/stats-service/src/main/java/com/example/devnote/stats_service/controller/ContentViewStatsController.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/controller/ContentViewStatsController.java
@@ -1,0 +1,78 @@
+package com.example.devnote.stats_service.controller;
+
+import com.example.devnote.stats_service.dto.ApiResponseDto;
+import com.example.devnote.stats_service.dto.DailyCountDto;
+import com.example.devnote.stats_service.dto.MonthlyCountDto;
+import com.example.devnote.stats_service.dto.YearlyCountDto;
+import com.example.devnote.stats_service.service.ContentViewStatsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 콘텐츠 조회수 통계 API 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stats/content-view")
+public class ContentViewStatsController {
+
+    private final ContentViewStatsService service;
+
+    /** 기간별 일일 콘텐츠 조회수 조회 */
+    @GetMapping("/daily")
+    public ResponseEntity<ApiResponseDto<List<DailyCountDto>>> getDaily(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+        List<DailyCountDto> data = service.getDailyStats(start, end);
+        return ResponseEntity.ok(ApiResponseDto.<List<DailyCountDto>>builder()
+                .message("Daily content view stats")
+                .statusCode(200)
+                .data(data)
+                .build());
+    }
+
+    /** 특정 연도의 월별 콘텐츠 조회수 조회 */
+    @GetMapping("/monthly")
+    public ResponseEntity<ApiResponseDto<List<MonthlyCountDto>>> getMonthly(@RequestParam int year) {
+        List<MonthlyCountDto> data = service.getMonthlyStats(year);
+        return ResponseEntity.ok(ApiResponseDto.<List<MonthlyCountDto>>builder()
+                .message("Monthly content view stats for " + year)
+                .statusCode(200)
+                .data(data)
+                .build());
+    }
+
+    /** 기간별 연간 콘텐츠 조회수 조회 */
+    @GetMapping("/yearly")
+    public ResponseEntity<ApiResponseDto<List<YearlyCountDto>>> getYearly(
+            @RequestParam int startYear, @RequestParam int endYear) {
+        List<YearlyCountDto> data = service.getYearlyStats(startYear, endYear);
+        return ResponseEntity.ok(ApiResponseDto.<List<YearlyCountDto>>builder()
+                .message("Yearly content view stats")
+                .statusCode(200)
+                .data(data)
+                .build());
+    }
+
+    /**
+     * 지정된 기간의 콘텐츠 조회수 통계를 재처리
+     * ** 추후 권한 부여 필요 (관리자용)
+     */
+    @PostMapping("/backfill")
+    public ResponseEntity<ApiResponseDto<String>> backfill(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+        service.backfillHistoricalStats(start, end);
+        String message = String.format("Backfill for content view stats from %s to %s has been triggered.", start, end);
+        return ResponseEntity.ok(ApiResponseDto.<String>builder()
+                .message(message)
+                .statusCode(200)
+                .data(null)
+                .build());
+    }
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/entity/ContentViewDailyStats.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/entity/ContentViewDailyStats.java
@@ -1,0 +1,29 @@
+package com.example.devnote.stats_service.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "content_view_daily_stats",
+        uniqueConstraints = @UniqueConstraint(name = "uk_view_stats_day", columnNames = {"day"}),
+        indexes = @Index(name = "idx_view_stats_day", columnList = "day"))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ContentViewDailyStats {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 통계 기준일 */
+    @Column(nullable = false)
+    private LocalDate day;
+
+    /** 해당 일의 총 콘텐츠 조회수 */
+    @Column(nullable = false)
+    private long count;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/repository/ContentViewDailyStatsRepository.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/repository/ContentViewDailyStatsRepository.java
@@ -1,0 +1,35 @@
+package com.example.devnote.stats_service.repository;
+
+import com.example.devnote.stats_service.entity.ContentViewDailyStats;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface ContentViewDailyStatsRepository extends JpaRepository<ContentViewDailyStats, Long> {
+
+    /** 기간 내 일별 데이터 조회 */
+    @Query("SELECT c.day as day, c.count as count FROM ContentViewDailyStats c WHERE c.day BETWEEN :start AND :end ORDER BY c.day ASC")
+    List<Object[]> findDailyCountsByRange(@Param("start") LocalDate start, @Param("end") LocalDate end);
+
+    /** 특정 연도의 월별 합계 조회 */
+    @Query("SELECT FUNCTION('MONTH', c.day) as month, SUM(c.count) as count " +
+            "FROM ContentViewDailyStats c " +
+            "WHERE FUNCTION('YEAR', c.day) = :year " +
+            "GROUP BY FUNCTION('MONTH', c.day) " +
+            "ORDER BY FUNCTION('MONTH', c.day) ASC")
+    List<Object[]> findMonthlyCountsByYear(@Param("year") int year);
+
+    /** 기간 내 연도별 합계 조회 */
+    @Query("SELECT FUNCTION('YEAR', c.day) as year, SUM(c.count) as count " +
+            "FROM ContentViewDailyStats c " +
+            "WHERE FUNCTION('YEAR', c.day) BETWEEN :startYear AND :endYear " +
+            "GROUP BY FUNCTION('YEAR', c.day) " +
+            "ORDER BY FUNCTION('YEAR', c.day) ASC")
+    List<Object[]> findYearlyCountsByRange(@Param("startYear") int startYear, @Param("endYear") int endYear);
+
+    Optional<ContentViewDailyStats> findByDay(LocalDate day);
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/repository/TrafficMinuteRepository.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/repository/TrafficMinuteRepository.java
@@ -42,4 +42,10 @@ public interface TrafficMinuteRepository extends JpaRepository<TrafficMinute, Lo
                       @Param("method") String method,
                       @Param("path") String path,
                       @Param("delta") long delta);
+
+    /** 특정 날짜의 콘텐츠 조회수(뉴스/유튜브) 합계를 조회 */
+    @Query("SELECT COALESCE(SUM(t.count), 0) FROM TrafficMinute t " +
+            "WHERE t.day = :date AND t.method = 'GET' " +
+            "AND (t.path LIKE '/api/v1/contents/%' OR t.path LIKE '/r/%')")
+    long sumContentViewsByDay(@Param("date") LocalDate date);
 }

--- a/stats-service/src/main/java/com/example/devnote/stats_service/service/ContentStatsService.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/service/ContentStatsService.java
@@ -75,7 +75,6 @@ public class ContentStatsService {
 
     /**
      * 특정 날짜의 Redis 카운트를 DB에 저장/업데이트하는 메서드
-     * @param dateToFlush 통계를 DB에 저장할 날짜
      */
     @Transactional
     public void flushStatsToDbForDate(LocalDate dateToFlush) {

--- a/stats-service/src/main/java/com/example/devnote/stats_service/service/ContentViewStatsService.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/service/ContentViewStatsService.java
@@ -1,0 +1,149 @@
+package com.example.devnote.stats_service.service;
+
+import com.example.devnote.stats_service.dto.DailyCountDto;
+import com.example.devnote.stats_service.dto.MonthlyCountDto;
+import com.example.devnote.stats_service.dto.YearlyCountDto;
+import com.example.devnote.stats_service.entity.ContentViewDailyStats;
+import com.example.devnote.stats_service.repository.ContentViewDailyStatsRepository;
+import com.example.devnote.stats_service.repository.TrafficMinuteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 콘텐츠 조회수 통계 서비스
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ContentViewStatsService {
+
+    private final StringRedisTemplate redis;
+    private final ContentViewDailyStatsRepository viewRepo;
+    private final TrafficMinuteRepository trafficRepo;
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter DAY_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    // Redis 키 포맷
+    private String dayCountKey(LocalDate day) {
+        return "stats:content_view:day:" + DAY_FMT.format(day);
+    }
+
+    /**
+     * 매일 자정에 어제 날짜의 Redis 카운트를 DB에 저장 (스케줄링)
+     */
+    @Scheduled(cron = "0 2 0 * * *", zone = "Asia/Seoul") // 다른 스케줄러와 겹치지 않게 2분에 실행
+    @Transactional
+    public void flushYesterdayStatsToDb() {
+        LocalDate yesterday = LocalDate.now(ZONE).minusDays(1);
+        String key = dayCountKey(yesterday);
+        String value = redis.opsForValue().get(key);
+        long count = (value != null) ? Long.parseLong(value) : 0L;
+
+        log.info("[STATS-VIEWS] Flushing yesterday's ({}) view count ({}) from Redis to DB.", yesterday, count);
+
+        ContentViewDailyStats stats = viewRepo.findByDay(yesterday)
+                .orElse(new ContentViewDailyStats(null, yesterday, 0L));
+        stats.setCount(count);
+        viewRepo.save(stats);
+
+        redis.delete(key);
+    }
+
+    /**
+     * 특정 날짜의 통계를 DB에 저장/업데이트 (백필용)
+     */
+    @Transactional
+    public void flushStatsToDbForDate(LocalDate dateToFlush) {
+        // 백필은 traffic_minute 테이블(Source of Truth)에서 직접 집계
+        long count = trafficRepo.sumContentViewsByDay(dateToFlush);
+
+        log.info("[STATS-VIEWS] Flushing date '{}' view count ({}) from DB to DB.", dateToFlush, count);
+
+        ContentViewDailyStats stats = viewRepo.findByDay(dateToFlush)
+                .orElse(new ContentViewDailyStats(null, dateToFlush, 0L));
+        stats.setCount(count);
+        viewRepo.save(stats);
+    }
+
+    /**
+     * 지정된 기간 동안의 통계를 DB 원본 데이터 기준으로 다시 계산하여 저장
+     */
+    public void backfillHistoricalStats(LocalDate start, LocalDate end) {
+        log.info("[STATS-VIEWS][BACKFILL] Starting backfill from {} to {}", start, end);
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            flushStatsToDbForDate(date);
+        }
+        log.info("[STATS-VIEWS][BACKFILL] Completed backfill.");
+    }
+
+    /**
+     * 오늘 콘텐츠 조회수 수 (실시간)
+     */
+    private long getTodayCount() {
+        LocalDate today = LocalDate.now(ZONE);
+        String value = redis.opsForValue().get(dayCountKey(today));
+        return (value != null) ? Long.parseLong(value) : 0L;
+    }
+
+    /**
+     * 기간별 일별 콘텐츠 조회수조회
+     */
+    public List<DailyCountDto> getDailyStats(LocalDate start, LocalDate end) {
+        Map<LocalDate, Long> dbCounts = viewRepo.findDailyCountsByRange(start, end).stream()
+                .collect(Collectors.toMap(row -> (LocalDate) row[0], row -> (long) row[1]));
+        List<DailyCountDto> result = new ArrayList<>();
+        LocalDate today = LocalDate.now(ZONE);
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            long count = date.equals(today) ? getTodayCount() : dbCounts.getOrDefault(date, 0L);
+            result.add(new DailyCountDto(date.format(DateTimeFormatter.ISO_LOCAL_DATE), count));
+        }
+        return result;
+    }
+
+    /**
+     * 특정 연도의 월별 콘텐츠 조회수조회
+     */
+    public List<MonthlyCountDto> getMonthlyStats(int year) {
+        Map<Integer, Long> dbCounts = viewRepo.findMonthlyCountsByYear(year).stream()
+                .collect(Collectors.toMap(row -> ((Number) row[0]).intValue(), row -> (long) row[1]));
+        LocalDate today = LocalDate.now(ZONE);
+        if (today.getYear() == year) {
+            dbCounts.merge(today.getMonthValue(), getTodayCount(), Long::sum);
+        }
+        List<MonthlyCountDto> result = new ArrayList<>();
+        for (int month = 1; month <= 12; month++) {
+            result.add(new MonthlyCountDto(month, dbCounts.getOrDefault(month, 0L)));
+        }
+        return result;
+    }
+
+    /**
+     * 기간별 연도별 콘텐츠 조회수 조회
+     */
+    public List<YearlyCountDto> getYearlyStats(int startYear, int endYear) {
+        Map<Integer, Long> dbCounts = viewRepo.findYearlyCountsByRange(startYear, endYear).stream()
+                .collect(Collectors.toMap(row -> ((Number) row[0]).intValue(), row -> (long) row[1]));
+        LocalDate today = LocalDate.now(ZONE);
+        if (today.getYear() >= startYear && today.getYear() <= endYear) {
+            dbCounts.merge(today.getYear(), getTodayCount(), Long::sum);
+        }
+        List<YearlyCountDto> result = new ArrayList<>();
+        for (int year = startYear; year <= endYear; year++) {
+            result.add(new YearlyCountDto(year, dbCounts.getOrDefault(year, 0L)));
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
콘텐츠 조회수의 통계를 측정하기 위해 로직을 추가했습니다. 조회일이 포함되지않은 데이터는 DB조회, 조회일이 포함되어있다면 redis에서 실시간 조회를 사용합니다