### PR TITLE
feat: 페이지 체류시간 통계 로직 추가 (DB + Redis)

### DIFF
--- a/stats-service/src/main/java/com/example/devnote/stats_service/controller/DurationStatsController.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/controller/DurationStatsController.java
@@ -1,0 +1,68 @@
+package com.example.devnote.stats_service.controller;
+
+import com.example.devnote.stats_service.dto.*;
+import com.example.devnote.stats_service.service.DurationStatsService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 페이지 체류 시간 통계 API 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stats/duration")
+public class DurationStatsController {
+
+    private final DurationStatsService service;
+
+    /**
+     * 프론트엔드로부터 주기적인 하트비트 신호를 받아 처리합니다.
+     */
+    @PostMapping("/heartbeat")
+    public ResponseEntity<Void> heartbeat(@Valid @RequestBody HeartbeatRequestDto req) {
+        service.handleHeartbeat(req.getPageViewId());
+        return ResponseEntity.ok().build();
+    }
+
+    /** 기간별 일일 체류시간 조회 */
+    @GetMapping("/daily")
+    public ResponseEntity<ApiResponseDto<List<DailyCountDto>>> getDaily(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+        List<DailyCountDto> data = service.getDailyStats(start, end);
+        return ResponseEntity.ok(ApiResponseDto.<List<DailyCountDto>>builder()
+                .message("Daily page view duration stats (seconds)")
+                .statusCode(200)
+                .data(data)
+                .build());
+    }
+
+    /** 특정 연도의 월별 체류시간 조회 */
+    @GetMapping("/monthly")
+    public ResponseEntity<ApiResponseDto<List<MonthlyCountDto>>> getMonthly(@RequestParam int year) {
+        List<MonthlyCountDto> data = service.getMonthlyStats(year);
+        return ResponseEntity.ok(ApiResponseDto.<List<MonthlyCountDto>>builder()
+                .message("Monthly page view duration stats for " + year + " (seconds)")
+                .statusCode(200)
+                .data(data)
+                .build());
+    }
+
+    /** 기간별 연간 체류시간 조회 */
+    @GetMapping("/yearly")
+    public ResponseEntity<ApiResponseDto<List<YearlyCountDto>>> getYearly(
+            @RequestParam int startYear, @RequestParam int endYear) {
+        List<YearlyCountDto> data = service.getYearlyStats(startYear, endYear);
+        return ResponseEntity.ok(ApiResponseDto.<List<YearlyCountDto>>builder()
+                .message("Yearly page view duration stats (seconds)")
+                .statusCode(200)
+                .data(data)
+                .build());
+    }
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/HeartbeatRequestDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/HeartbeatRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.devnote.stats_service.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class HeartbeatRequestDto {
+    @NotBlank
+    private String pageViewId;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/entity/PageDurationDailyStats.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/entity/PageDurationDailyStats.java
@@ -1,0 +1,29 @@
+package com.example.devnote.stats_service.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "page_duration_daily_stats",
+        uniqueConstraints = @UniqueConstraint(name = "uk_duration_stats_day", columnNames = {"day"}),
+        indexes = @Index(name = "idx_duration_stats_day", columnList = "day"))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PageDurationDailyStats {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 통계 기준일 */
+    @Column(nullable = false)
+    private LocalDate day;
+
+    /** 해당 일의 총 체류 시간 (단위: 초) */
+    @Column(nullable = false)
+    private long totalDurationSeconds;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/repository/PageDurationDailyStatsRepository.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/repository/PageDurationDailyStatsRepository.java
@@ -1,0 +1,35 @@
+package com.example.devnote.stats_service.repository;
+
+import com.example.devnote.stats_service.entity.PageDurationDailyStats;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface PageDurationDailyStatsRepository extends JpaRepository<PageDurationDailyStats, Long> {
+
+    /** 기간 내 일별 데이터 조회 */
+    @Query("SELECT p.day as day, p.totalDurationSeconds as count FROM PageDurationDailyStats p WHERE p.day BETWEEN :start AND :end ORDER BY p.day ASC")
+    List<Object[]> findDailyDurationsByRange(@Param("start") LocalDate start, @Param("end") LocalDate end);
+
+    /** 특정 연도의 월별 합계 조회 */
+    @Query("SELECT FUNCTION('MONTH', p.day) as month, SUM(p.totalDurationSeconds) as count " +
+            "FROM PageDurationDailyStats p " +
+            "WHERE FUNCTION('YEAR', p.day) = :year " +
+            "GROUP BY FUNCTION('MONTH', p.day) " +
+            "ORDER BY FUNCTION('MONTH', p.day) ASC")
+    List<Object[]> findMonthlyDurationsByYear(@Param("year") int year);
+
+    /** 기간 내 연도별 합계 조회 */
+    @Query("SELECT FUNCTION('YEAR', p.day) as year, SUM(p.totalDurationSeconds) as count " +
+            "FROM PageDurationDailyStats p " +
+            "WHERE FUNCTION('YEAR', p.day) BETWEEN :startYear AND :endYear " +
+            "GROUP BY FUNCTION('YEAR', p.day) " +
+            "ORDER BY FUNCTION('YEAR', p.day) ASC")
+    List<Object[]> findYearlyDurationsByRange(@Param("startYear") int startYear, @Param("endYear") int endYear);
+
+    Optional<PageDurationDailyStats> findByDay(LocalDate day);
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/service/DurationStatsService.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/service/DurationStatsService.java
@@ -1,0 +1,190 @@
+package com.example.devnote.stats_service.service;
+
+import com.example.devnote.stats_service.dto.DailyCountDto;
+import com.example.devnote.stats_service.dto.MonthlyCountDto;
+import com.example.devnote.stats_service.dto.YearlyCountDto;
+import com.example.devnote.stats_service.entity.PageDurationDailyStats;
+import com.example.devnote.stats_service.repository.PageDurationDailyStatsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 페이지 체류 시간 통계 서비스
+ * - 프론트엔드의 하트비트 신호를 받아 Redis에 실시간으로 세션 정보를 기록
+ * - 1분 주기의 스케줄러로 종료된 세션을 정리하며 일일 총 체류 시간을 Redis에 누적
+ * - 자정 스케줄러로 Redis의 최종 집계치를 DB에 영속화
+ * - 일/월/연 단위 조회 API 제공
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class DurationStatsService {
+
+    private final StringRedisTemplate redis;
+    private final PageDurationDailyStatsRepository repo;
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter DAY_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final int HEARTBEAT_INTERVAL_SECONDS = 15;
+    private static final int SESSION_TIMEOUT_SECONDS = HEARTBEAT_INTERVAL_SECONDS * 3; // 45초
+
+    // Redis 키 포맷
+    private String sessionKey(String pageViewId) { return "duration:view:" + pageViewId; }
+    private String activeSessionKey() { return "duration:active_sessions"; }
+    private String dailyTotalKey(LocalDate day) { return "stats:duration:total:day:" + DAY_FMT.format(day); }
+
+    /**
+     * 프론트엔드로부터 하트비트 요청을 받아 Redis에 기록
+     */
+    public void handleHeartbeat(String pageViewId) {
+        long now = System.currentTimeMillis();
+        String sessionKey = sessionKey(pageViewId);
+
+        // 키가 없을 때만 startTime을 기록 (첫 하트비트)
+        redis.opsForHash().putIfAbsent(sessionKey, "startTime", String.valueOf(now));
+
+        // 마지막 확인 시간은 항상 갱신
+        redis.opsForHash().put(sessionKey, "lastSeen", String.valueOf(now));
+
+        // 키는 넉넉하게 10분 뒤 만료되도록 설정
+        redis.expire(sessionKey, Duration.ofMinutes(10));
+
+        // 활성 세션 목록(Sorted Set)에 마지막 확인 시간을 점수(score)로 하여 추가
+        // 시간 초과된 세션을 효율적으로 찾기 위함
+        redis.opsForZSet().add(activeSessionKey(), pageViewId, now);
+    }
+
+    /**
+     * 1분마다 실행되어 응답이 없는 세션(타임아웃)을 종료 처리하고 체류 시간 집계
+     */
+    @Scheduled(fixedDelayString = "60000")
+    public void reapEndedSessions() {
+        long timeoutThreshold = System.currentTimeMillis() - (SESSION_TIMEOUT_SECONDS * 1000L);
+
+        // 1. 타임아웃된 세션 ID들을 Sorted Set에서 찾기
+        Set<String> expiredSessionIds = redis.opsForZSet().rangeByScore(activeSessionKey(), 0, timeoutThreshold);
+        if (expiredSessionIds == null || expiredSessionIds.isEmpty()) {
+            return;
+        }
+        log.info("[STATS-DURATION] Found {} expired sessions to reap.", expiredSessionIds.size());
+
+        for (String pageViewId : expiredSessionIds) {
+            String sessionKey = sessionKey(pageViewId);
+            // 2. 세션 정보(시작시간, 마지막 확인시간)를 Redis Hash에서 가져오기
+            Map<Object, Object> sessionData = redis.opsForHash().entries(sessionKey);
+            String startStr = (String) sessionData.get("startTime");
+            String lastSeenStr = (String) sessionData.get("lastSeen");
+
+            if (startStr != null && lastSeenStr != null) {
+                long startTime = Long.parseLong(startStr);
+                long lastSeenTime = Long.parseLong(lastSeenStr);
+                long durationSeconds = (lastSeenTime - startTime) / 1000; // 초 단위로 변환
+
+                // 3. 오늘 날짜의 총 체류 시간에 합산
+                LocalDate today = LocalDate.now(ZONE);
+                redis.opsForValue().increment(dailyTotalKey(today), durationSeconds);
+                redis.expire(dailyTotalKey(today), Duration.ofDays(2)); // TTL 설정
+            }
+
+            // 4. 처리 완료된 세션 정보(Hash) 및 활성 목록(ZSet)에서 삭제
+            redis.delete(sessionKey);
+            redis.opsForZSet().remove(activeSessionKey(), pageViewId);
+        }
+    }
+
+    /**
+     * 매일 자정에 어제 날짜의 Redis 카운트를 DB에 저장 (스케줄링)
+     */
+    @Scheduled(cron = "0 3 0 * * *", zone = "Asia/Seoul") // 새벽 00:03에 실행
+    @Transactional
+    public void flushYesterdayStatsToDb() {
+        LocalDate yesterday = LocalDate.now(ZONE).minusDays(1);
+        String key = dailyTotalKey(yesterday);
+        String value = redis.opsForValue().get(key);
+        long totalSeconds = (value != null) ? Long.parseLong(value) : 0L;
+
+        log.info("[STATS-DURATION] Flushing yesterday's ({}) total duration ({}s) to DB.", yesterday, totalSeconds);
+
+        PageDurationDailyStats stats = repo.findByDay(yesterday)
+                .orElse(new PageDurationDailyStats(null, yesterday, 0L));
+        stats.setTotalDurationSeconds(totalSeconds);
+        repo.save(stats);
+
+        redis.delete(key);
+    }
+
+    /**
+     * 오늘 총 체류시간 (실시간)
+     */
+    private long getTodayTotalSeconds() {
+        String value = redis.opsForValue().get(dailyTotalKey(LocalDate.now(ZONE)));
+        return (value != null) ? Long.parseLong(value) : 0L;
+    }
+
+    /**
+     * 기간별 일별 총 체류시간 조회
+     */
+    public List<DailyCountDto> getDailyStats(LocalDate start, LocalDate end) {
+        Map<LocalDate, Long> dbDurations = repo.findDailyDurationsByRange(start, end).stream()
+                .collect(Collectors.toMap(row -> (LocalDate) row[0], row -> (long) row[1]));
+        List<DailyCountDto> result = new ArrayList<>();
+        LocalDate today = LocalDate.now(ZONE);
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            long duration = date.equals(today) ? getTodayTotalSeconds() : dbDurations.getOrDefault(date, 0L);
+            result.add(new DailyCountDto(date.format(DateTimeFormatter.ISO_LOCAL_DATE), duration));
+        }
+        return result;
+    }
+
+    /**
+     * 특정 연도의 월별 총 체류시간 조회
+     */
+    public List<MonthlyCountDto> getMonthlyStats(int year) {
+        Map<Integer, Long> dbDurations = repo.findMonthlyDurationsByYear(year).stream()
+                .collect(Collectors.toMap(row -> ((Number) row[0]).intValue(), row -> (long) row[1]));
+
+        LocalDate today = LocalDate.now(ZONE);
+        if (today.getYear() == year) {
+            dbDurations.merge(today.getMonthValue(), getTodayTotalSeconds(), Long::sum);
+        }
+
+        List<MonthlyCountDto> result = new ArrayList<>();
+        for (int month = 1; month <= 12; month++) {
+            result.add(new MonthlyCountDto(month, dbDurations.getOrDefault(month, 0L)));
+        }
+        return result;
+    }
+
+    /**
+     * 기간별 연도별 총 체류시간 조회
+     */
+    public List<YearlyCountDto> getYearlyStats(int startYear, int endYear) {
+        Map<Integer, Long> dbDurations = repo.findYearlyDurationsByRange(startYear, endYear).stream()
+                .collect(Collectors.toMap(row -> ((Number) row[0]).intValue(), row -> (long) row[1]));
+
+        LocalDate today = LocalDate.now(ZONE);
+        if (today.getYear() >= startYear && today.getYear() <= endYear) {
+            dbDurations.merge(today.getYear(), getTodayTotalSeconds(), Long::sum);
+        }
+
+        List<YearlyCountDto> result = new ArrayList<>();
+        for (int year = startYear; year <= endYear; year++) {
+            result.add(new YearlyCountDto(year, dbDurations.getOrDefault(year, 0L)));
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
페이지 체류시간의 통계를 측정하기 위해 로직을 추가했습니다. 조회일이 포함되지않은 데이터는 DB조회, 조회일이 포함되어있다면 redis에서 실시간 조회를 사용합니다