### PR TITLE
feat: 랭킹 로직 추가 (최상위 찜 채널/콘텐츠, 보유댓글 랭킹, 활동점수 랭킹)

### DIFF
--- a/stats-service/src/main/java/com/example/devnote/stats_service/controller/RankingController.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/controller/RankingController.java
@@ -1,0 +1,90 @@
+package com.example.devnote.stats_service.controller;
+
+import com.example.devnote.stats_service.dto.*;
+import com.example.devnote.stats_service.service.RankingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+// import reactor.core.publisher.Mono; // Mono 사용 안 함
+
+import java.util.List;
+
+/**
+ * 랭킹 통계 API 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stats/ranking")
+public class RankingController {
+
+    private final RankingService rankingService;
+
+    /**
+     * 가장 많이 찜한 콘텐츠 TOP 50 (페이지당 10개)
+     */
+    @GetMapping("/content-favorites")
+    public ResponseEntity<ApiResponseDto<PageResponseDto<RankedContentDto>>> getTopFavoritedContents(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        PageResponseDto<RankedContentDto> pagedData = rankingService.getTopFavoritedContents(page, size);
+        return ResponseEntity.ok(
+                ApiResponseDto.<PageResponseDto<RankedContentDto>>builder()
+                        .message("Top 50 favorited contents")
+                        .statusCode(200)
+                        .data(pagedData)
+                        .build()
+        );
+    }
+
+    /**
+     * 가장 댓글이 많은 콘텐츠 TOP 50 (페이지당 10개)
+     */
+    @GetMapping("/content-comments")
+    public ResponseEntity<ApiResponseDto<PageResponseDto<RankedContentDto>>> getTopCommentedContents(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        PageResponseDto<RankedContentDto> pagedData = rankingService.getTopCommentedContents(page, size);
+        return ResponseEntity.ok(
+                ApiResponseDto.<PageResponseDto<RankedContentDto>>builder()
+                        .message("Top 50 commented contents")
+                        .statusCode(200)
+                        .data(pagedData)
+                        .build()
+        );
+    }
+
+    /**
+     * 가장 많이 찜한 채널 TOP 10
+     */
+    @GetMapping("/channel-favorites")
+    public ResponseEntity<ApiResponseDto<List<RankedChannelDto>>> getTopFavoritedChannels() {
+        List<RankedChannelDto> data = rankingService.getTopFavoritedChannels();
+        return ResponseEntity.ok(
+                ApiResponseDto.<List<RankedChannelDto>>builder()
+                        .message("Top 10 favorited channels")
+                        .statusCode(200)
+                        .data(data)
+                        .build()
+        );
+    }
+
+    /**
+     * 활동 우수 사용자 TOP 10
+     */
+    @GetMapping("/active-users")
+    public ResponseEntity<ApiResponseDto<List<RankedUserDto>>> getTopActiveUsers() {
+        List<RankedUserDto> data = rankingService.getTopActiveUsers();
+        return ResponseEntity.ok(
+                ApiResponseDto.<List<RankedUserDto>>builder()
+                        .message("Top 10 active users")
+                        .statusCode(200)
+                        .data(data)
+                        .build()
+        );
+    }
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/ChannelSubscriptionDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/ChannelSubscriptionDto.java
@@ -1,0 +1,15 @@
+package com.example.devnote.stats_service.dto;
+
+import lombok.Data;
+
+/**
+ * news-youtube-service로부터 채널 상세 정보를 받아오기 위한 DTO
+ */
+@Data
+public class ChannelSubscriptionDto {
+    private Long id;
+    private String youtubeName;
+    private String channelId;
+    private String channelThumbnailUrl;
+    private Long subscriberCount;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/ContentDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/ContentDto.java
@@ -1,0 +1,31 @@
+package com.example.devnote.stats_service.dto;
+
+import lombok.Data;
+
+import java.time.Instant;
+
+/**
+ * processor-service로부터 콘텐츠 상세 정보를 받아오기 위한 DTO
+ */
+@Data
+public class ContentDto {
+    private Long id;
+    private String source;       // "NEWS" or "YOUTUBE"
+    private String category;     // "BACKEND", "FRONTEND", "DEVOPS" 등 추가
+    private String channelId;    // 유튜브 채널 ID
+    private String title;        // 제목
+    private String description;  // 설명 (News 전용)
+    private String link;         // 콘텐츠 원본 링크
+    private String thumbnailUrl; // 썸네일 URL (YouTube 전용)
+    private Instant publishedAt; // 게시일
+    private Instant createdAt;   // 생성일
+
+    // 유튜브
+    private String channelTitle;        // 유튜브 채널명
+    private String channelThumbnailUrl; // 채널 썸네일
+    private Long viewCount;             // 영상 조회수
+    private Long localViewCount;        // 로컬 영상 조회수
+    private Long durationSeconds;       // 영상 길이(초)
+    private String videoForm;           // "SHORTS" or "LONGFORM"
+    private Long subscriberCount;       // 구독자 수
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/PageResponseDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/PageResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.devnote.stats_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PageResponseDto<T> {
+    private List<T> items;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/RankedChannelDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/RankedChannelDto.java
@@ -1,0 +1,23 @@
+package com.example.devnote.stats_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 채널 랭킹 정보를 최종적으로 반환하기 위한 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RankedChannelDto {
+    private long rank;                  // 순위
+    private long count;                 // 찜 수
+    private Long id;
+    private String youtubeName;
+    private String channelId;
+    private String channelThumbnailUrl;
+    private Long subscriberCount;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/RankedContentDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/RankedContentDto.java
@@ -1,0 +1,36 @@
+package com.example.devnote.stats_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * 콘텐츠 랭킹 정보를 최종적으로 반환하기 위한 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RankedContentDto {
+    private long rank;              // 순위
+    private long count;             // 집계 수 (찜 또는 댓글)
+    private Long id;
+    private String source;
+    private String category;
+    private String title;
+    private String link;
+    private String thumbnailUrl;
+    private Instant publishedAt;
+    private String channelTitle;
+    private Long viewCount;
+    private String description;
+    private Instant createdAt;
+    private String channelThumbnailUrl;
+    private Long localViewCount;
+    private Long durationSeconds;
+    private String videoForm;
+    private Long subscriberCount;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/RankedUserDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/RankedUserDto.java
@@ -1,0 +1,21 @@
+package com.example.devnote.stats_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 활동 우수 사용자 랭킹 정보를 최종적으로 반환하기 위한 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RankedUserDto {
+    private long rank;
+    private Long id;
+    private String name;
+    private String picture;
+    private Integer activityScore;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/internal/RankedChannelIdDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/internal/RankedChannelIdDto.java
@@ -1,0 +1,12 @@
+package com.example.devnote.stats_service.dto.internal;
+
+import lombok.Data;
+
+/**
+ * user-service로부터 채널 랭킹 ID 목록을 받아오기 위한 DTO
+ */
+@Data
+public class RankedChannelIdDto {
+    private Long channelId;
+    private long count;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/internal/RankedContentIdDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/internal/RankedContentIdDto.java
@@ -1,0 +1,12 @@
+package com.example.devnote.stats_service.dto.internal;
+
+import lombok.Data;
+
+/**
+ * user-service로부터 콘텐츠 랭킹 ID 목록을 받아오기 위한 DTO
+ */
+@Data
+public class RankedContentIdDto {
+    private Long contentId;
+    private long count;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/internal/RankedUserDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/internal/RankedUserDto.java
@@ -1,0 +1,14 @@
+package com.example.devnote.stats_service.dto.internal;
+
+import lombok.Data;
+
+/**
+ * user-service로부터 활동 우수 사용자 목록을 받아오기 위한 DTO
+ */
+@Data
+public class RankedUserDto {
+    private Long id;
+    private String name;
+    private String picture;
+    private Integer activityScore;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/service/RankingService.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/service/RankingService.java
@@ -1,0 +1,247 @@
+package com.example.devnote.stats_service.service;
+
+import com.example.devnote.stats_service.dto.*;
+import com.example.devnote.stats_service.dto.internal.RankedChannelIdDto;
+import com.example.devnote.stats_service.dto.internal.RankedContentIdDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+/**
+ * 랭킹 데이터를 다른 서비스로부터 조합하여 제공하는 서비스
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RankingService {
+
+    private final WebClient.Builder webClientBuilder;
+
+    /**
+     * 가장 많이 찜한 콘텐츠 TOP 50 조회
+     */
+    public PageResponseDto<RankedContentDto> getTopFavoritedContents(int page, int size) {
+        // 1. user-service에서 찜 많은 순서대로 contentId 목록과 찜 수를 가져옴
+        RestPageResponse<RankedContentIdDto> pagedIds = webClientBuilder.baseUrl("http://user-service").build()
+                .get()
+                .uri("/internal/ranking/content-favorites?page={page}&size={size}", page, size)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<RestPageResponse<RankedContentIdDto>>() {})
+                .block();
+
+        if (pagedIds == null || pagedIds.getContent().isEmpty()) {
+            return PageResponseDto.<RankedContentDto>builder().items(List.of()).page(page).size(size).build();
+        }
+
+        // 2. 각 contentId로 processor-service에 상세 정보를 요청
+        AtomicLong rankCounter = new AtomicLong(pagedIds.getNumber() * pagedIds.getSize() + 1);
+        List<RankedContentDto> rankedItems = pagedIds.getContent().stream()
+                .map(rankedId -> {
+                    ApiResponseDto<ContentDto> details = fetchContentDetailsBlocking(rankedId.getContentId());
+                    return toRankedContentDto(rankedId, details, rankCounter.getAndIncrement());
+                })
+                .collect(Collectors.toList());
+
+        return PageResponseDto.<RankedContentDto>builder()
+                .items(rankedItems)
+                .page(pagedIds.getNumber())
+                .size(pagedIds.getSize())
+                .totalElements(pagedIds.getTotalElements())
+                .totalPages(pagedIds.getTotalPages())
+                .build();
+    }
+
+    /**
+     * 가장 댓글이 많은 콘텐츠 TOP 50 조회
+     */
+    public PageResponseDto<RankedContentDto> getTopCommentedContents(int page, int size) {
+        RestPageResponse<RankedContentIdDto> pagedIds = webClientBuilder.baseUrl("http://user-service").build()
+                .get()
+                .uri("/internal/ranking/content-comments?page={page}&size={size}", page, size)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<RestPageResponse<RankedContentIdDto>>() {})
+                .block();
+
+        if (pagedIds == null || pagedIds.getContent().isEmpty()) {
+            return PageResponseDto.<RankedContentDto>builder().items(List.of()).page(page).size(size).build();
+        }
+
+        AtomicLong rankCounter = new AtomicLong(pagedIds.getNumber() * pagedIds.getSize() + 1);
+        List<RankedContentDto> rankedItems = pagedIds.getContent().stream()
+                .map(rankedId -> {
+                    ApiResponseDto<ContentDto> details = fetchContentDetailsBlocking(rankedId.getContentId());
+                    return toRankedContentDto(rankedId, details, rankCounter.getAndIncrement());
+                })
+                .collect(Collectors.toList());
+
+        return PageResponseDto.<RankedContentDto>builder()
+                .items(rankedItems)
+                .page(pagedIds.getNumber())
+                .size(pagedIds.getSize())
+                .totalElements(pagedIds.getTotalElements())
+                .totalPages(pagedIds.getTotalPages())
+                .build();
+    }
+
+    /**
+     * 가장 많이 찜한 채널 TOP 10 조회
+     */
+    public List<RankedChannelDto> getTopFavoritedChannels() {
+        List<RankedChannelIdDto> rankedIds = webClientBuilder.baseUrl("http://user-service").build()
+                .get()
+                .uri("/internal/ranking/channel-favorites")
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<RankedChannelIdDto>>() {})
+                .block();
+
+        if (rankedIds == null || rankedIds.isEmpty()) {
+            return List.of();
+        }
+
+        AtomicLong rankCounter = new AtomicLong(1);
+        return rankedIds.stream()
+                .map(rankedId -> {
+                    ApiResponseDto<ChannelSubscriptionDto> details = fetchChannelDetailsBlocking(rankedId.getChannelId());
+                    return toRankedChannelDto(rankedId, details, rankCounter.getAndIncrement());
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 활동 우수 사용자 TOP 10 조회 (순차 처리)
+     */
+    public List<com.example.devnote.stats_service.dto.RankedUserDto> getTopActiveUsers() {
+        // 1. user-service에서 활동 우수 사용자 목록을 가져옴
+        List<RankedUserDto> users = webClientBuilder.baseUrl("http://user-service").build()
+                .get()
+                .uri("/internal/ranking/active-users")
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<RankedUserDto>>() {})
+                .block();
+
+        if (users == null || users.isEmpty()) {
+            return List.of();
+        }
+
+        // 2. 순위를 매겨서 최종 DTO로 변환
+        AtomicLong rankCounter = new AtomicLong(1);
+        return users.stream()
+                .map(user -> toRankedUserDto(user, rankCounter.getAndIncrement()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * (Helper) 최종 응답 DTO로 변환
+     */
+    private com.example.devnote.stats_service.dto.RankedUserDto toRankedUserDto(RankedUserDto internalDto, long rank) {
+        return com.example.devnote.stats_service.dto.RankedUserDto.builder()
+                .rank(rank)
+                .id(internalDto.getId())
+                .name(internalDto.getName())
+                .picture(internalDto.getPicture())
+                .activityScore(internalDto.getActivityScore())
+                .build();
+    }
+
+    /**
+     * (Helper) contentId로 상세 정보 조회 (블로킹 방식)
+     */
+    private ApiResponseDto<ContentDto> fetchContentDetailsBlocking(Long contentId) {
+        try {
+            return webClientBuilder.baseUrl("http://processor-service").build()
+                    .get()
+                    .uri("/api/v1/contents/{id}", contentId)
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<ApiResponseDto<ContentDto>>() {})
+                    .block();
+        } catch (Exception e) {
+            log.error("Failed to fetch content details for id={}: {}", contentId, e.getMessage());
+            return new ApiResponseDto<>();
+        }
+    }
+
+    /**
+     * (Helper) channelId로 상세 정보 조회 (블로킹 방식)
+     */
+    private ApiResponseDto<ChannelSubscriptionDto> fetchChannelDetailsBlocking(Long channelId) {
+        try {
+            return webClientBuilder.baseUrl("http://news-youtube-service").build()
+                    .get()
+                    .uri("/api/v1/channels/{id}", channelId)
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<ApiResponseDto<ChannelSubscriptionDto>>() {})
+                    .block();
+        } catch (Exception e) {
+            log.error("Failed to fetch channel details for id={}: {}", channelId, e.getMessage());
+            return new ApiResponseDto<>();
+        }
+    }
+
+    private RankedContentDto toRankedContentDto(RankedContentIdDto id, ApiResponseDto<ContentDto> details, long rank) {
+        ContentDto data = details.getData();
+        if (data == null) {
+            return RankedContentDto.builder()
+                    .rank(rank)
+                    .count(id.getCount())
+                    .id(id.getContentId())
+                    .title("콘텐츠 정보를 찾을 수 없습니다.")
+                    .build();
+        }
+        return RankedContentDto.builder()
+                .rank(rank)
+                .count(id.getCount())
+                .id(data.getId())
+                .source(data.getSource())
+                .category(data.getCategory())
+                .title(data.getTitle())
+                .link(data.getLink())
+                .thumbnailUrl(data.getThumbnailUrl())
+                .publishedAt(data.getPublishedAt())
+                .channelTitle(data.getChannelTitle())
+                .viewCount(data.getViewCount())
+                .description(data.getDescription())
+                .createdAt(data.getCreatedAt())
+                .channelThumbnailUrl(data.getChannelThumbnailUrl())
+                .localViewCount(data.getLocalViewCount())
+                .durationSeconds(data.getDurationSeconds())
+                .videoForm(data.getVideoForm())
+                .subscriberCount(data.getSubscriberCount())
+                .build();
+    }
+
+    private RankedChannelDto toRankedChannelDto(RankedChannelIdDto id, ApiResponseDto<ChannelSubscriptionDto> details, long rank) {
+        ChannelSubscriptionDto data = details.getData();
+        if (data == null) {
+            return RankedChannelDto.builder()
+                    .rank(rank)
+                    .count(id.getCount())
+                    .id(id.getChannelId())
+                    .youtubeName("채널 정보를 찾을 수 없습니다.")
+                    .build();
+        }
+        return RankedChannelDto.builder()
+                .rank(rank)
+                .count(id.getCount())
+                .id(data.getId())
+                .youtubeName(data.getYoutubeName())
+                .channelId(data.getChannelId())
+                .channelThumbnailUrl(data.getChannelThumbnailUrl())
+                .subscriberCount(data.getSubscriberCount())
+                .build();
+    }
+
+    @lombok.Data
+    private static class RestPageResponse<T> {
+        private List<T> content;
+        private int number;
+        private int size;
+        private long totalElements;
+        private int totalPages;
+    }
+}

--- a/user-service/src/main/java/com/example/devnote/config/JwtAuthenticationFilter.java
+++ b/user-service/src/main/java/com/example/devnote/config/JwtAuthenticationFilter.java
@@ -57,4 +57,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         chain.doFilter(req, res);
     }
+
+    /**
+     * 이 필터를 적용하지 않을 경로를 지정
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return request.getRequestURI().startsWith("/internal/");
+    }
 }

--- a/user-service/src/main/java/com/example/devnote/config/JwtRefreshFilter.java
+++ b/user-service/src/main/java/com/example/devnote/config/JwtRefreshFilter.java
@@ -83,4 +83,13 @@ public class JwtRefreshFilter extends OncePerRequestFilter {
 
         chain.doFilter(req, res);
     }
+
+    /**
+     * 이 필터를 적용하지 않을 경로를 지정
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        // /internal/** 경로로 들어오는 요청은 이 필터를 건너뜁니다.
+        return request.getRequestURI().startsWith("/internal/");
+    }
 }

--- a/user-service/src/main/java/com/example/devnote/controller/InternalRankingController.java
+++ b/user-service/src/main/java/com/example/devnote/controller/InternalRankingController.java
@@ -1,0 +1,70 @@
+package com.example.devnote.controller;
+
+import com.example.devnote.dto.RankedChannelIdDto;
+import com.example.devnote.dto.RankedContentIdDto;
+import com.example.devnote.dto.RankedUserDto;
+import com.example.devnote.service.RankingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 서비스 간 통신(내부용)을 위한 랭킹 데이터 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/ranking")
+public class InternalRankingController {
+
+    private final RankingService rankingService;
+
+    /**
+     * 가장 많이 찜한 콘텐츠 ID 목록
+     */
+    @GetMapping("/content-favorites")
+    public ResponseEntity<Page<RankedContentIdDto>> getTopFavoritedContents(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<RankedContentIdDto> result = rankingService.getTopFavoritedContents(PageRequest.of(page, size));
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 가장 댓글이 많은 콘텐츠 ID 목록
+     */
+    @GetMapping("/content-comments")
+    public ResponseEntity<Page<RankedContentIdDto>> getTopCommentedContents(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<RankedContentIdDto> result = rankingService.getTopCommentedContents(PageRequest.of(page, size));
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 가장 많이 찜한 채널 ID 목록
+     */
+    @GetMapping("/channel-favorites")
+    public ResponseEntity<List<RankedChannelIdDto>> getTopFavoritedChannels() {
+        // 상위 10개만 조회
+        List<RankedChannelIdDto> result = rankingService.getTopFavoritedChannels(PageRequest.of(0, 10));
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 활동 점수가 높은 사용자 TOP 10 목록
+     */
+    @GetMapping("/active-users")
+    public ResponseEntity<List<RankedUserDto>> getTopActiveUsers() {
+        List<RankedUserDto> result = rankingService.getTopActiveUsers();
+        return ResponseEntity.ok(result);
+    }
+}

--- a/user-service/src/main/java/com/example/devnote/dto/RankedChannelIdDto.java
+++ b/user-service/src/main/java/com/example/devnote/dto/RankedChannelIdDto.java
@@ -1,0 +1,17 @@
+package com.example.devnote.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 채널 랭킹 집계 결과를 담는 DTO
+ * (내부 서비스 통신용)
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RankedChannelIdDto {
+    private Long channelId; // 채널 ID
+    private long count;     // 집계된 찜 수
+}

--- a/user-service/src/main/java/com/example/devnote/dto/RankedContentIdDto.java
+++ b/user-service/src/main/java/com/example/devnote/dto/RankedContentIdDto.java
@@ -1,0 +1,17 @@
+package com.example.devnote.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 콘텐츠 랭킹 집계 결과를 담는 DTO
+ * (내부 서비스 통신용)
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RankedContentIdDto {
+    private Long contentId; // 콘텐츠 ID
+    private long count;     // 집계된 수 (찜 또는 댓글 수)
+}

--- a/user-service/src/main/java/com/example/devnote/dto/RankedUserDto.java
+++ b/user-service/src/main/java/com/example/devnote/dto/RankedUserDto.java
@@ -1,0 +1,21 @@
+package com.example.devnote.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 활동 우수 사용자 랭킹 정보를 담는 DTO
+ * (내부 서비스 통신용)
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RankedUserDto {
+    private Long id;
+    private String name;
+    private String picture;
+    private Integer activityScore;
+}

--- a/user-service/src/main/java/com/example/devnote/repository/CommentRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/CommentRepository.java
@@ -1,6 +1,9 @@
 package com.example.devnote.repository;
 
+import com.example.devnote.dto.RankedContentIdDto;
 import com.example.devnote.entity.CommentEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,4 +27,13 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
     /** 특정 날짜에 생성된 총 댓글 수 (대댓글 포함) */
     @Query("SELECT COUNT(c) FROM CommentEntity c WHERE FUNCTION('DATE', c.createdAt) = :date")
     long countByCreatedAt(@Param("date") LocalDate date);
+
+    /**
+     * 가장 많이 댓글이 달린 콘텐츠 ID와 댓글 수를 페이지네이션하여 조회
+     */
+    @Query("SELECT new com.example.devnote.dto.RankedContentIdDto(c.contentId, COUNT(c.id)) " +
+            "FROM CommentEntity c " +
+            "GROUP BY c.contentId " +
+            "ORDER BY COUNT(c.id) DESC, c.contentId ASC")
+    Page<RankedContentIdDto> findTopCommentedContentIds(Pageable pageable);
 }

--- a/user-service/src/main/java/com/example/devnote/repository/FavoriteChannelRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/FavoriteChannelRepository.java
@@ -1,7 +1,10 @@
 package com.example.devnote.repository;
 
+import com.example.devnote.dto.RankedChannelIdDto;
 import com.example.devnote.entity.FavoriteChannel;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +13,12 @@ public interface FavoriteChannelRepository extends JpaRepository<FavoriteChannel
     Optional<FavoriteChannel> findByUserIdAndChannelSubscriptionId(Long userId, Long chSubId);
     List<FavoriteChannel> findByUserId(Long userId);
     void deleteByChannelSubscriptionId(Long channelSubscriptionId);
+    /**
+     * 가장 많이 찜한 채널 ID와 찜 수를 페이지네이션하여 조회
+     */
+    @Query("SELECT new com.example.devnote.dto.RankedChannelIdDto(fc.channelSubscriptionId, COUNT(fc.id)) " +
+            "FROM FavoriteChannel fc " +
+            "GROUP BY fc.channelSubscriptionId " +
+            "ORDER BY COUNT(fc.id) DESC, fc.channelSubscriptionId ASC")
+    List<RankedChannelIdDto> findTopFavoritedChannelIds(Pageable pageable);
 }

--- a/user-service/src/main/java/com/example/devnote/repository/FavoriteContentRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/FavoriteContentRepository.java
@@ -1,7 +1,11 @@
 package com.example.devnote.repository;
 
+import com.example.devnote.dto.RankedContentIdDto;
 import com.example.devnote.entity.FavoriteContent;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +14,12 @@ public interface FavoriteContentRepository extends JpaRepository<FavoriteContent
     Optional<FavoriteContent> findByUserIdAndContentId(Long userId, Long contentId);
     List<FavoriteContent> findByUserId(Long userId);
     void deleteByContentId(Long contentId);
+    /**
+     * 가장 많이 찜한 콘텐츠 ID와 찜 수를 페이지네이션하여 조회
+     */
+    @Query("SELECT new com.example.devnote.dto.RankedContentIdDto(fc.contentId, COUNT(fc.id)) " +
+            "FROM FavoriteContent fc " +
+            "GROUP BY fc.contentId " +
+            "ORDER BY COUNT(fc.id) DESC, fc.contentId ASC")
+    Page<RankedContentIdDto> findTopFavoritedContentIds(Pageable pageable);
 }

--- a/user-service/src/main/java/com/example/devnote/repository/UserRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/UserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -21,4 +22,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying
     @Query("UPDATE User u SET u.activityScore = u.activityScore - 1 WHERE u.id = :userId")
     void decrementActivityScore(@Param("userId") Long userId);
+
+    /**
+     * 활동 점수가 가장 높은 사용자 상위 10명을 조회
+     */
+    List<User> findTop10ByOrderByActivityScoreDesc();
 }

--- a/user-service/src/main/java/com/example/devnote/service/RankingService.java
+++ b/user-service/src/main/java/com/example/devnote/service/RankingService.java
@@ -1,0 +1,74 @@
+package com.example.devnote.service;
+
+import com.example.devnote.dto.RankedChannelIdDto;
+import com.example.devnote.dto.RankedContentIdDto;
+import com.example.devnote.dto.RankedUserDto;
+import com.example.devnote.entity.User;
+import com.example.devnote.repository.CommentRepository;
+import com.example.devnote.repository.FavoriteChannelRepository;
+import com.example.devnote.repository.FavoriteContentRepository;
+import com.example.devnote.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 랭킹 데이터 집계 비즈니스 로직을 처리하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RankingService {
+
+    private final FavoriteContentRepository favoriteContentRepository;
+    private final CommentRepository commentRepository;
+    private final FavoriteChannelRepository favoriteChannelRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 가장 많이 찜한 콘텐츠 랭킹 조회
+     */
+    public Page<RankedContentIdDto> getTopFavoritedContents(Pageable pageable) {
+        return favoriteContentRepository.findTopFavoritedContentIds(pageable);
+    }
+
+    /**
+     * 가장 댓글이 많은 콘텐츠 랭킹 조회
+     */
+    public Page<RankedContentIdDto> getTopCommentedContents(Pageable pageable) {
+        return commentRepository.findTopCommentedContentIds(pageable);
+    }
+
+    /**
+     * 가장 많이 찜한 채널 랭킹 조회
+     */
+    public List<RankedChannelIdDto> getTopFavoritedChannels(Pageable pageable) {
+        return favoriteChannelRepository.findTopFavoritedChannelIds(pageable);
+    }
+
+    /**
+     * 활동 점수가 높은 사용자 TOP 10 조회
+     */
+    public List<RankedUserDto> getTopActiveUsers() {
+        return userRepository.findTop10ByOrderByActivityScoreDesc().stream()
+                .map(this::toRankedUserDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * User Entity -> RankedUserDto 변환 헬퍼 메서드
+     */
+    private RankedUserDto toRankedUserDto(User user) {
+        return RankedUserDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .picture(user.getPicture())
+                .activityScore(user.getActivityScore())
+                .build();
+    }
+}


### PR DESCRIPTION
랭킹 기능을 추가하기 위해 로직을 추가했습니다.
상세정보는 아래와 같습니다.

- 가장 많이 찜한 콘텐츠 TOP 50개 (페이지네이션 페이지당 10)
- 가장 많이 찜한 채널 TOP 10개
- 댓글이 가장 많이 달린 콘텐츠 TOP 50개 (페이지네이션 페이지당 10)
- 활동 우수 사용자 랭킹 TOP 10명
