### PR TITLE
feat: kafka 를 사용한 검색 정렬 조건 추가 (찜 많은순, 댓글 많은순)

### DIFF
--- a/processor-service/build.gradle
+++ b/processor-service/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	// GEMINI
 	implementation 'com.google.genai:google-genai:1.0.0'
 
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	annotationProcessor 'org.projectlombok:lombok'
 	implementation 'org.projectlombok:lombok'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/processor-service/src/main/java/com/example/devnote/processor_service/config/KafkaConsumerConfig.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/config/KafkaConsumerConfig.java
@@ -1,6 +1,7 @@
 package com.example.devnote.processor_service.config;
 
 import com.example.devnote.processor_service.dto.ContentMessageDto;
+import com.example.devnote.processor_service.dto.ContentStatsUpdateDto;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -54,6 +55,28 @@ public class KafkaConsumerConfig {
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
         log.info("KafkaListenerContainerFactory configured");
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, ContentStatsUpdateDto> statsUpdateConsumerFactory() {
+        Map<String, Object> cfg = new HashMap<>(props.buildConsumerProperties());
+        // 통계 업데이트용 Consumer Group ID를 별도로 지정
+        cfg.put(ConsumerConfig.GROUP_ID_CONFIG, "processor-service-group-stats");
+
+        JsonDeserializer<ContentStatsUpdateDto> deserializer =
+                new JsonDeserializer<>(ContentStatsUpdateDto.class, false);
+        deserializer.addTrustedPackages("*");
+
+        return new DefaultKafkaConsumerFactory<>(cfg, new StringDeserializer(), deserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ContentStatsUpdateDto>
+    statsUpdateContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ContentStatsUpdateDto> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(statsUpdateConsumerFactory());
         return factory;
     }
 }

--- a/processor-service/src/main/java/com/example/devnote/processor_service/dto/ContentStatsUpdateDto.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/dto/ContentStatsUpdateDto.java
@@ -1,0 +1,19 @@
+package com.example.devnote.processor_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 콘텐츠의 통계(찜/댓글) 변경을 알리기 위한 Kafka 메시지 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentStatsUpdateDto {
+    private Long contentId;
+    private int favoriteDelta; // 찜 증감 (+1 또는 -1)
+    private int commentDelta;  // 댓글 증감 (+1 또는 -1)
+}

--- a/processor-service/src/main/java/com/example/devnote/processor_service/entity/ContentEntity.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/entity/ContentEntity.java
@@ -48,6 +48,14 @@ public class ContentEntity {
     @Builder.Default
     private Long localViewCount = 0L;
 
+    @Column(name = "favorite_count", nullable = false)
+    @Builder.Default
+    private Long favoriteCount = 0L;
+
+    @Column(name = "comment_count", nullable = false)
+    @Builder.Default
+    private Long commentCount = 0L;
+
     private Long viewCount;
     private Long durationSeconds;
     private String thumbnailUrl;

--- a/processor-service/src/main/java/com/example/devnote/processor_service/service/ContentStatsListener.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/service/ContentStatsListener.java
@@ -1,0 +1,36 @@
+package com.example.devnote.processor_service.service;
+
+import com.example.devnote.processor_service.dto.ContentStatsUpdateDto;
+import com.example.devnote.processor_service.repository.ContentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ContentStatsListener {
+
+    private final ContentRepository contentRepository;
+
+    /**
+     * 'content-stats-update' 토픽을 구독하여 찜/댓글 수를 DB에 반영
+     */
+    @KafkaListener(
+            topics = "content-stats-update",
+            containerFactory = "statsUpdateContainerFactory"
+    )
+    @Transactional
+    public void listen(ContentStatsUpdateDto message) {
+        log.info("Received stats update message: {}", message);
+        contentRepository.findById(message.getContentId()).ifPresent(content -> {
+            // 현재 값에 변화량(delta)을 더하여 업데이트
+            content.setFavoriteCount(content.getFavoriteCount() + message.getFavoriteDelta());
+            content.setCommentCount(content.getCommentCount() + message.getCommentDelta());
+            // 변경된 내용 저장
+            contentRepository.save(content);
+        });
+    }
+}

--- a/user-service/src/main/java/com/example/devnote/config/KafkaProducerConfig.java
+++ b/user-service/src/main/java/com/example/devnote/config/KafkaProducerConfig.java
@@ -1,0 +1,37 @@
+package com.example.devnote.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    /**
+     * DTO와 같은 객체를 JSON으로 직렬화하는 ProducerFactory를 생성
+     */
+    @Bean
+    public ProducerFactory<String, Object> jsonProducerFactory(KafkaProperties properties) {
+        Map<String, Object> props = new HashMap<>(properties.buildProducerProperties());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    /**
+     * jsonProducerFactory를 사용하는 KafkaTemplate을 생성
+     */
+    @Bean
+    public KafkaTemplate<String, Object> jsonKafkaTemplate(ProducerFactory<String, Object> jsonProducerFactory) {
+        return new KafkaTemplate<>(jsonProducerFactory);
+    }
+}

--- a/user-service/src/main/java/com/example/devnote/dto/ContentStatsUpdateDto.java
+++ b/user-service/src/main/java/com/example/devnote/dto/ContentStatsUpdateDto.java
@@ -1,0 +1,19 @@
+package com.example.devnote.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 콘텐츠의 통계(찜/댓글) 변경을 알리기 위한 Kafka 메시지 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentStatsUpdateDto {
+    private Long contentId;
+    private int favoriteDelta; // 찜 증감 (+1 또는 -1)
+    private int commentDelta;  // 댓글 증감 (+1 또는 -1)
+}


### PR DESCRIPTION
콘텐츠 엔티티에 찜, 댓글 수 컬럼을 추가했습니다
찜과 댓글이 추가/삭제 될때마다 kafka를 사용해 콘텐츠 엔티티의 찜/댓글 수 값을 변경합니다