### PR TITLE
feat: 엘라스틱서치 기반 콘텐츠 검색 기능 구현

### DIFF
--- a/processor-service/build.gradle
+++ b/processor-service/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 	runtimeOnly   'org.mariadb.jdbc:mariadb-java-client'
 	// Redis 캐시
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// Elasticsearch
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
 	// GEMINI
 	implementation 'com.google.genai:google-genai:1.0.0'

--- a/processor-service/src/main/java/com/example/devnote/processor_service/controller/ContentSearchController.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/controller/ContentSearchController.java
@@ -1,0 +1,42 @@
+package com.example.devnote.processor_service.controller;
+
+import com.example.devnote.processor_service.dto.ApiResponseDto;
+import com.example.devnote.processor_service.es.EsContent;
+import com.example.devnote.processor_service.service.ContentSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/contents/search")
+public class ContentSearchController {
+    private final ContentSearchService contentSearchService;
+
+    /**
+     * 콘텐츠 검색 API
+     * @param q 검색할 키워드
+     * @param pageable 페이지네이션 정보 (예: /search?q=스프링&page=0&size=10)
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponseDto<Page<EsContent>>> search(
+            @RequestParam("q") String q,
+            @PageableDefault(size = 24) Pageable pageable) {
+
+        Page<EsContent> result = contentSearchService.search(q, pageable);
+
+        return ResponseEntity.ok(
+                ApiResponseDto.<Page<EsContent>>builder()
+                        .message("Content search successful")
+                        .statusCode(200)
+                        .data(result)
+                        .build()
+        );
+    }
+}

--- a/processor-service/src/main/java/com/example/devnote/processor_service/controller/SyncController.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/controller/SyncController.java
@@ -1,0 +1,50 @@
+package com.example.devnote.processor_service.controller;
+
+import com.example.devnote.processor_service.dto.ApiResponseDto;
+import com.example.devnote.processor_service.service.SyncService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+/**
+ * MariaDB와 Elasticsearch 간의 데이터 동기화를 위한 관리자용 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/sync")
+public class SyncController {
+    private final SyncService syncService;
+
+    /**
+     * 지정된 기간의 콘텐츠 데이터를 MariaDB에서 Elasticsearch로 동기화
+     * @param start 동기화 시작일 (YYYY-MM-DD)
+     * @param end   동기화 종료일 (YYYY-MM-DD)
+     */
+    @PostMapping("/contents")
+    public ResponseEntity<ApiResponseDto<Map<String, Object>>> syncContents(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+
+        long syncedCount = syncService.syncContentsByDateRange(start, end);
+
+        Map<String, Object> responseData = Map.of(
+                "period", start + " to " + end,
+                "syncedCount", syncedCount
+        );
+
+        return ResponseEntity.ok(
+                ApiResponseDto.<Map<String, Object>>builder()
+                        .message("Data synchronization triggered successfully.")
+                        .statusCode(200)
+                        .data(responseData)
+                        .build()
+        );
+    }
+}

--- a/processor-service/src/main/java/com/example/devnote/processor_service/es/EsContent.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/es/EsContent.java
@@ -1,0 +1,67 @@
+package com.example.devnote.processor_service.es;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.elasticsearch.annotations.*;
+
+import java.time.Instant;
+
+/**
+ * Elasticsearch 'contents' 인덱스에 저장될 문서
+ */
+@Data
+@Builder
+@Document(indexName = "contents")
+public class EsContent {
+    @Id
+    private Long id;
+
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, analyzer = "korean_analyzer"), // (1) 전문 검색용 (형태소 분석)
+            otherFields = { @InnerField(suffix = "keyword", type = FieldType.Keyword) } // (2) 정확한 값 정렬/집계용
+    )
+    private String title;
+
+    @Field(type = FieldType.Text, analyzer = "korean_analyzer")
+    private String description;
+
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, analyzer = "korean_analyzer"),
+            otherFields = { @InnerField(suffix = "keyword", type = FieldType.Keyword) }
+    )
+    private String channelTitle;
+
+    @Field(type = FieldType.Keyword)
+    private String category;
+
+    @Field(type = FieldType.Keyword)
+    private String source;
+
+    @Field(type = FieldType.Keyword)
+    private String channelId;
+
+    @Field(type = FieldType.Date, format = DateFormat.epoch_millis)
+    private Instant publishedAt;
+
+    @Field(type = FieldType.Date, format = DateFormat.epoch_millis)
+    private Instant createdAt;
+
+    @Field(type = FieldType.Long)
+    private Long viewCount;
+
+    @Field(type = FieldType.Long)
+    private Long localViewCount;
+
+    @Field(type = FieldType.Long)
+    private Long durationSeconds;
+
+    @Field(type = FieldType.Long)
+    private Long subscriberCount;
+
+    @Field(type = FieldType.Long)
+    private Long favoriteCount;
+
+    @Field(type = FieldType.Long)
+    private Long commentCount;
+}

--- a/processor-service/src/main/java/com/example/devnote/processor_service/es/EsContentRepository.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/es/EsContentRepository.java
@@ -1,0 +1,6 @@
+package com.example.devnote.processor_service.es;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface EsContentRepository extends ElasticsearchRepository<EsContent, Long> {
+}

--- a/processor-service/src/main/java/com/example/devnote/processor_service/service/ContentSearchService.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/service/ContentSearchService.java
@@ -1,0 +1,49 @@
+package com.example.devnote.processor_service.service;
+
+import com.example.devnote.processor_service.es.EsContent;
+import com.example.devnote.processor_service.es.EsContentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RestController;
+
+@Service
+@RequiredArgsConstructor
+public class ContentSearchService {
+    private final EsContentRepository esContentRepository;
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    /**
+     * 키워드로 콘텐츠를 검색합니다. (페이지네이션 지원)
+     * @param keyword 검색어
+     * @param pageable 페이지 정보
+     * @return 검색된 EsContent 페이지
+     */
+    public Page<EsContent> search(String keyword, Pageable pageable) {
+        // 'title', 'description', 'channelTitle' 필드에서 키워드를 검색하는 쿼리를 생성
+        Query query = NativeQuery.builder()
+                .withQuery(q -> q
+                        .multiMatch(mm -> mm
+                                .query(keyword)
+                                .fields("title", "description", "channelTitle")
+                        )
+                )
+                .withPageable(pageable)
+                .build();
+
+        // 쿼리 실행
+        SearchHits<EsContent> searchHits = elasticsearchOperations.search(query, EsContent.class);
+
+        // SearchHits를 Page 객체로 변환 후 반환
+        return org.springframework.data.support.PageableExecutionUtils.getPage(
+                searchHits.getSearchHits().stream().map(org.springframework.data.elasticsearch.core.SearchHit::getContent).toList(),
+                pageable,
+                searchHits::getTotalHits
+        );
+    }
+}

--- a/processor-service/src/main/java/com/example/devnote/processor_service/service/SyncService.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/service/SyncService.java
@@ -1,0 +1,114 @@
+package com.example.devnote.processor_service.service;
+
+import com.example.devnote.processor_service.entity.ContentEntity;
+import com.example.devnote.processor_service.es.EsContent;
+import com.example.devnote.processor_service.es.EsContentRepository;
+import com.example.devnote.processor_service.repository.ContentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SyncService {
+
+    private final ContentRepository contentRepository;
+    private final EsContentRepository esContentRepository;
+
+    /**
+     * 매 시간마다 최근 1시간 동안 생성/수정된 데이터를 자동으로 동기화
+     * 매 정시 0분 0초에 실행
+     */
+    @Scheduled(cron = "0 0 * * * *")
+    public void scheduleHourlySync() {
+        log.info("[SCHEDULED] Starting hourly data reconciliation.");
+
+        // 현재 시간 기준으로 1시간 전 데이터에 대해 동기화 실행
+        Instant oneHourAgo = Instant.now().minusSeconds(3600);
+        Instant now = Instant.now();
+
+        Specification<ContentEntity> spec = (root, query, cb) ->
+                cb.between(root.get("createdAt"), oneHourAgo, now);
+
+        List<ContentEntity> recentContents = contentRepository.findAll(spec);
+
+        if (recentContents.isEmpty()) {
+            log.info("[SCHEDULED] No recent data to sync.");
+            return;
+        }
+
+        List<EsContent> esDocuments = recentContents.stream()
+                .map(this::toEsContent)
+                .toList();
+
+        esContentRepository.saveAll(esDocuments);
+
+        log.info("[SCHEDULED] Automatically reconciled {} documents.", esDocuments.size());
+    }
+
+    /**
+     * 지정된 날짜 범위의 데이터를 MariaDB에서 읽어 Elasticsearch에 재색인
+     * @param start 시작일
+     * @param end   종료일
+     * @return 동기화된 문서의 개수
+     */
+    @Transactional(readOnly = true)
+    public long syncContentsByDateRange(LocalDate start, LocalDate end) {
+        log.info("Starting data sync from {} to {}", start, end);
+
+        // 1. 기간에 해당하는 데이터를 MariaDB에서 조회
+        Instant startInstant = start.atStartOfDay().toInstant(ZoneOffset.UTC);
+        Instant endInstant = end.atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
+
+        Specification<ContentEntity> spec = (root, query, cb) ->
+                cb.between(root.get("createdAt"), startInstant, endInstant);
+
+        List<ContentEntity> contentsFromDb = contentRepository.findAll(spec);
+
+        if (contentsFromDb.isEmpty()) {
+            log.info("No data to sync in the given period.");
+            return 0;
+        }
+
+        // 2. 조회된 데이터를 Elasticsearch 문서 형식으로 변환
+        List<EsContent> esDocuments = contentsFromDb.stream()
+                .map(this::toEsContent)
+                .toList();
+
+        // 3. Elasticsearch에 일괄 저장(saveAll)
+        esContentRepository.saveAll(esDocuments);
+
+        log.info("Successfully synced {} documents to Elasticsearch.", esDocuments.size());
+        return esDocuments.size();
+    }
+
+    private EsContent toEsContent(ContentEntity e) {
+        return EsContent.builder()
+                .id(e.getId())
+                .title(e.getTitle())
+                .description(e.getDescription())
+                .channelTitle(e.getChannelTitle())
+                .category(e.getCategory())
+                .source(e.getSource())
+                .channelId(e.getChannelId())
+                .publishedAt(e.getPublishedAt())
+                .createdAt(e.getCreatedAt())
+                .viewCount(e.getViewCount())
+                .localViewCount(e.getLocalViewCount())
+                .durationSeconds(e.getDurationSeconds())
+                .subscriberCount(e.getSubscriberCount())
+                .favoriteCount(e.getFavoriteCount())
+                .commentCount(e.getCommentCount())
+                .build();
+    }
+}


### PR DESCRIPTION
- Spring Data Elasticsearch 의존성 추가 및 연결 설정
- Kafka 메시지 수신 시 MariaDB와 Elasticsearch에 이중 쓰기(dual-write)로 데이터를 동기화하는 로직 추가
- 콘텐츠 통계 업데이트 및 삭제 시 Elasticsearch에도 변경사항을 실시간으로 반영
- Elasticsearch를 직접 조회하는 검색 API 구현 (`GET /api/v1/contents/search`)
- 데이터 불일치 발생 시 복구할 수 있는 수동 API 및 자동 스케줄러 기반의 동기화 기능 추가