### PR TITLE
feat: 실시간 인기 검색어 TOP 10 기능 구현

### DIFF
--- a/processor-service/src/main/java/com/example/devnote/processor_service/controller/ContentSearchController.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/controller/ContentSearchController.java
@@ -3,6 +3,7 @@ package com.example.devnote.processor_service.controller;
 import com.example.devnote.processor_service.dto.ApiResponseDto;
 import com.example.devnote.processor_service.es.EsContent;
 import com.example.devnote.processor_service.service.ContentSearchService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,13 +24,15 @@ public class ContentSearchController {
      * 콘텐츠 검색 API
      * @param q 검색할 키워드
      * @param pageable 페이지네이션 정보 (예: /search?q=스프링&page=0&size=10)
+     *
      */
     @GetMapping
     public ResponseEntity<ApiResponseDto<Page<EsContent>>> search(
             @RequestParam("q") String q,
-            @PageableDefault(size = 24) Pageable pageable) {
+            @PageableDefault(size = 24) Pageable pageable,
+            HttpServletRequest request) {
 
-        Page<EsContent> result = contentSearchService.search(q, pageable);
+        Page<EsContent> result = contentSearchService.search(q, pageable, request);
 
         return ResponseEntity.ok(
                 ApiResponseDto.<Page<EsContent>>builder()

--- a/processor-service/src/main/java/com/example/devnote/processor_service/es/EsSearchLog.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/es/EsSearchLog.java
@@ -1,0 +1,28 @@
+package com.example.devnote.processor_service.es;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.Instant;
+
+/**
+ * Elasticsearch 'search_logs' 인덱스에 저장될 문서
+ */
+@Data
+@Builder
+@Document(indexName = "search_logs")
+public class EsSearchLog {
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Keyword)
+    private String query; // 검색어
+
+    @Field(type = FieldType.Date, format = DateFormat.epoch_millis)
+    private Instant timestamp;
+}

--- a/processor-service/src/main/java/com/example/devnote/processor_service/es/EsSearchLogRepository.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/es/EsSearchLogRepository.java
@@ -1,0 +1,6 @@
+package com.example.devnote.processor_service.es;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface EsSearchLogRepository extends ElasticsearchRepository<EsSearchLog, String> {
+}

--- a/processor-service/src/main/java/com/example/devnote/processor_service/service/CategoryClassificationService.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/service/CategoryClassificationService.java
@@ -35,26 +35,26 @@ public class CategoryClassificationService {
     /**
      * 1시간마다 카테고리가 'TBC'인 콘텐츠를 Source별로 조회하여 분류
      */
-    @Scheduled(fixedDelayString = "3600000")
-    public void classifyTbcContents() {
-        // 1. 유튜브 콘텐츠 분류
-        List<ContentEntity> youtubeToClassify = contentRepository.findBySourceAndCategory("YOUTUBE", "TBC");
-        if (!youtubeToClassify.isEmpty()) {
-            log.info("[AI-CLASSIFY] Found {} YOUTUBE contents to classify.", youtubeToClassify.size());
-            processBatch(youtubeToClassify, props.getYoutube());
-        }
-
-        // 2. 뉴스 콘텐츠 분류
-        List<ContentEntity> newsToClassify = contentRepository.findBySourceAndCategory("NEWS", "TBC");
-        if (!newsToClassify.isEmpty()) {
-            log.info("[AI-CLASSIFY] Found {} NEWS contents to classify.", newsToClassify.size());
-            processBatch(newsToClassify, props.getNews());
-        }
-
-        if (youtubeToClassify.isEmpty() && newsToClassify.isEmpty()) {
-            log.info("[AI-CLASSIFY] No content to classify.");
-        }
-    }
+//    @Scheduled(fixedDelayString = "3600000")
+//    public void classifyTbcContents() {
+//        // 1. 유튜브 콘텐츠 분류
+//        List<ContentEntity> youtubeToClassify = contentRepository.findBySourceAndCategory("YOUTUBE", "TBC");
+//        if (!youtubeToClassify.isEmpty()) {
+//            log.info("[AI-CLASSIFY] Found {} YOUTUBE contents to classify.", youtubeToClassify.size());
+//            processBatch(youtubeToClassify, props.getYoutube());
+//        }
+//
+//        // 2. 뉴스 콘텐츠 분류
+//        List<ContentEntity> newsToClassify = contentRepository.findBySourceAndCategory("NEWS", "TBC");
+//        if (!newsToClassify.isEmpty()) {
+//            log.info("[AI-CLASSIFY] Found {} NEWS contents to classify.", newsToClassify.size());
+//            processBatch(newsToClassify, props.getNews());
+//        }
+//
+//        if (youtubeToClassify.isEmpty() && newsToClassify.isEmpty()) {
+//            log.info("[AI-CLASSIFY] No content to classify.");
+//        }
+//    }
 
     /**
      * 주어진 콘텐츠 목록을 특정 분류 체계(Scheme)에 따라 배치 처리

--- a/processor-service/src/main/java/com/example/devnote/processor_service/service/ContentSearchService.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/service/ContentSearchService.java
@@ -2,6 +2,9 @@ package com.example.devnote.processor_service.service;
 
 import com.example.devnote.processor_service.es.EsContent;
 import com.example.devnote.processor_service.es.EsContentRepository;
+import com.example.devnote.processor_service.es.EsSearchLog;
+import com.example.devnote.processor_service.es.EsSearchLogRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,22 +12,27 @@ import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class ContentSearchService {
-    private final EsContentRepository esContentRepository;
+    private final EsSearchLogRepository searchLogRepository;
     private final ElasticsearchOperations elasticsearchOperations;
+    private final StringRedisTemplate redisTemplate;
 
     /**
-     * 키워드로 콘텐츠를 검색합니다. (페이지네이션 지원)
-     * @param keyword 검색어
-     * @param pageable 페이지 정보
-     * @return 검색된 EsContent 페이지
+     * 키워드로 콘텐츠를 검색하고, IP기반으로 10분에 한 번씩 검색어 로그 남기기
      */
-    public Page<EsContent> search(String keyword, Pageable pageable) {
+    public Page<EsContent> search(String keyword, Pageable pageable, HttpServletRequest request) {
+        // 검색어 로깅 시도
+        logSearchQuery(keyword, request);
+
         // 'title', 'description', 'channelTitle' 필드에서 키워드를 검색하는 쿼리를 생성
         Query query = NativeQuery.builder()
                 .withQuery(q -> q
@@ -45,5 +53,29 @@ public class ContentSearchService {
                 pageable,
                 searchHits::getTotalHits
         );
+    }
+
+    /**
+     * 검색어 로깅 (IP 기반 10분 제한 추가)
+     */
+    private void logSearchQuery(String query, HttpServletRequest request) {
+        // 1. 요청자 IP 추출
+        String ipAddress = Optional.ofNullable(request.getHeader("X-Forwarded-For")).orElse(request.getRemoteAddr());
+        String trimmedQuery = query.trim();
+
+        // 2. Redis에 사용할 키 생성
+        String redisKey = "search_log_limit:ip:" + ipAddress + ":" + trimmedQuery;
+
+        // 3. Redis에 해당 키가 있는지 확인. setIfAbsent는 키가 없을 때만 true를 반환
+        Boolean isFirstTime = redisTemplate.opsForValue().setIfAbsent(redisKey, "1", Duration.ofMinutes(10));
+
+        // 4. 키가 성공적으로 세팅되었다면 (10분 내에 처음 검색한 키워드라면) 로그 저장
+        if (Boolean.TRUE.equals(isFirstTime)) {
+            EsSearchLog log = EsSearchLog.builder()
+                    .query(trimmedQuery)
+                    .timestamp(Instant.now())
+                    .build();
+            searchLogRepository.save(log);
+        }
     }
 }

--- a/stats-service/build.gradle
+++ b/stats-service/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 	// Scheduling
 	implementation 'org.springframework.boot:spring-boot-starter'
 
+	// Elasticsearch
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
 	// 테스트
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/stats-service/src/main/java/com/example/devnote/stats_service/controller/RankingController.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/controller/RankingController.java
@@ -1,8 +1,11 @@
 package com.example.devnote.stats_service.controller;
 
 import com.example.devnote.stats_service.dto.*;
+import com.example.devnote.stats_service.es.RankedSearchTermDto;
 import com.example.devnote.stats_service.service.RankingService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 // import reactor.core.publisher.Mono; // Mono 사용 안 함
 
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * 랭킹 통계 API 컨트롤러
@@ -21,6 +26,7 @@ import java.util.List;
 public class RankingController {
 
     private final RankingService rankingService;
+    private final StringRedisTemplate redisTemplate;
 
     /**
      * 가장 많이 찜한 콘텐츠 TOP 50 (페이지당 10개)
@@ -84,6 +90,35 @@ public class RankingController {
                         .message("Top 10 active users")
                         .statusCode(200)
                         .data(data)
+                        .build()
+        );
+    }
+
+    /**
+     * 실시간 인기 검색어 TOP 10 조회
+     */
+    @GetMapping("/search-terms")
+    public ResponseEntity<ApiResponseDto<List<RankedSearchTermDto>>> getTopSearchTerms() {
+        String rankingKey = "ranking:search_terms";
+
+        // Redis의 Sorted Set에서 점수가 높은 순으로 10개 조회
+        Set<ZSetOperations.TypedTuple<String>> topTerms = redisTemplate.opsForZSet()
+                .reverseRangeWithScores(rankingKey, 0, 9);
+
+        AtomicLong rank = new AtomicLong(1);
+        List<RankedSearchTermDto> result = topTerms.stream()
+                .map(tuple -> RankedSearchTermDto.builder()
+                        .rank(rank.getAndIncrement())
+                        .term(tuple.getValue())
+                        .score(tuple.getScore())
+                        .build())
+                .toList();
+
+        return ResponseEntity.ok(
+                ApiResponseDto.<List<RankedSearchTermDto>>builder()
+                        .message("Top 10 real-time search terms")
+                        .statusCode(200)
+                        .data(result)
                         .build()
         );
     }

--- a/stats-service/src/main/java/com/example/devnote/stats_service/es/EsSearchLog.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/es/EsSearchLog.java
@@ -1,0 +1,23 @@
+package com.example.devnote.stats_service.es;
+
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.Instant;
+
+@Data
+@Document(indexName = "search_logs")
+public class EsSearchLog {
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Keyword)
+    private String query;
+
+    @Field(type = FieldType.Date, format = DateFormat.epoch_millis)
+    private Instant timestamp;
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/es/EsSearchLogRepository.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/es/EsSearchLogRepository.java
@@ -1,0 +1,11 @@
+package com.example.devnote.stats_service.es;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface EsSearchLogRepository extends ElasticsearchRepository<EsSearchLog, String> {
+    List<EsSearchLog> findByTimestampBetween(Instant start, Instant end, Pageable pageable);
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/es/RankedSearchTermDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/es/RankedSearchTermDto.java
@@ -1,0 +1,16 @@
+package com.example.devnote.stats_service.es;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RankedSearchTermDto {
+    private long rank;      // 순위
+    private String term;    // 검색어
+    private double score;   // 가중치가 적용된 점수
+}

--- a/stats-service/src/main/java/com/example/devnote/stats_service/service/SearchStatsService.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/service/SearchStatsService.java
@@ -1,0 +1,80 @@
+package com.example.devnote.stats_service.service;
+
+import com.example.devnote.stats_service.es.EsSearchLog;
+import com.example.devnote.stats_service.es.EsSearchLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SearchStatsService {
+
+    private final EsSearchLogRepository searchLogRepository;
+    private final StringRedisTemplate redisTemplate;
+    private static final String RANKING_KEY = "ranking:search_terms";
+
+    /**
+     * 10분마다 실행되어 인기 검색어 랭킹을 갱신
+     */
+    @Scheduled(fixedRate = 600000, initialDelay = 60000)
+    public void updateUserSearchRanking() {
+        log.info("[SCHEDULED] Starting popular search term ranking update.");
+
+        Instant now = Instant.now();
+        Map<String, Double> scoreMap = new HashMap<>();
+
+        // 1. 시간대별로 가중치를 다르게 하여 검색 로그를 조회하고 점수를 합산
+        // - 최근 1시간 내 검색어: 10점
+        addScores(scoreMap, searchLogsBetween(now.minus(1, ChronoUnit.HOURS), now), 10.0);
+        // - 1시간 전 ~ 6시간 전 검색어: 5점
+        addScores(scoreMap, searchLogsBetween(now.minus(6, ChronoUnit.HOURS), now.minus(1, ChronoUnit.HOURS)), 5.0);
+        // - 6시간 전 ~ 24시간 전 검색어: 1점
+        addScores(scoreMap, searchLogsBetween(now.minus(24, ChronoUnit.HOURS), now.minus(6, ChronoUnit.HOURS)), 1.0);
+
+        // 2. Redis에 새로운 랭킹을 업데이트
+        if (!scoreMap.isEmpty()) {
+            String tempKey = RANKING_KEY + ":temp";
+            redisTemplate.delete(tempKey); // 임시 키 초기화
+
+            scoreMap.forEach((query, score) ->
+                    redisTemplate.opsForZSet().add(tempKey, query, score)
+            );
+
+            // 임시 키의 이름을 실제 랭킹 키로 변경
+            redisTemplate.rename(tempKey, RANKING_KEY);
+            log.info("Updated popular search term ranking with {} terms.", scoreMap.size());
+        } else {
+            redisTemplate.delete(RANKING_KEY); // 집계된 결과가 없으면 기존 랭킹 삭제
+            log.info("No recent search terms to rank. Cleared existing ranking.");
+        }
+    }
+
+    /**
+     * Elasticsearch에서 특정 기간의 검색 로그 조회 메서드
+     */
+    private List<EsSearchLog> searchLogsBetween(Instant start, Instant end) {
+        PageRequest pageable = PageRequest.of(0, 10000);
+        return searchLogRepository.findByTimestampBetween(start, end, pageable);
+    }
+
+
+    /**
+     * 조회된 로그 목록을 바탕으로 점수 맵에 가중치를 더하는 메서드
+     */
+    private void addScores(Map<String, Double> scoreMap, List<EsSearchLog> logs, double weight) {
+        for (EsSearchLog log : logs) {
+            scoreMap.merge(log.getQuery(), weight, Double::sum);
+        }
+    }
+}


### PR DESCRIPTION
- 사용자가 검색 시, IP기반으로 10분당 1회씩 검색어 로그를 Elasticsearch의 `search_logs` 인덱스에 익명으로 기록합니다.
- 10분마다 스케줄러를 실행하여 `search_logs`를 집계합니다.
- 최신 검색어에 더 높은 가중치를 부여하는 시간 감쇠(Time-decay) 점수를 계산하여 Redis Sorted Set에 실시간 랭킹을 저장합니다.
-  `GET /api/v1/stats/ranking/search-terms-realtime` API를 통해 최종 TOP 10 순위를 제공합니다.