### PR TITLE
fix: 검색 필터링 기능 추가

### DIFF
--- a/processor-service/src/main/java/com/example/devnote/processor_service/controller/ContentSearchController.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/controller/ContentSearchController.java
@@ -23,16 +23,22 @@ public class ContentSearchController {
     /**
      * 콘텐츠 검색 API
      * @param q 검색할 키워드
-     * @param pageable 페이지네이션 정보 (예: /search?q=스프링&page=0&size=10)
-     *
+     * @param source 검색 대상 소스 ("YOUTUBE" 또는 "NEWS")
+     * @param category (선택) 필터링할 카테고리
+     * @param sort (선택) 정렬 옵션
+     * @param pageable 페이지네이션 정보
+     * @param request 요청 객체
      */
     @GetMapping
     public ResponseEntity<ApiResponseDto<Page<EsContent>>> search(
             @RequestParam("q") String q,
+            @RequestParam("source") String source,
+            @RequestParam(required = false) String category,
+            @RequestParam(defaultValue = "relevance") String sort,
             @PageableDefault(size = 24) Pageable pageable,
             HttpServletRequest request) {
 
-        Page<EsContent> result = contentSearchService.search(q, pageable, request);
+        Page<EsContent> result = contentSearchService.search(q, source, category, sort, pageable, request);
 
         return ResponseEntity.ok(
                 ApiResponseDto.<Page<EsContent>>builder()

--- a/processor-service/src/main/java/com/example/devnote/processor_service/service/ContentSearchService.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/service/ContentSearchService.java
@@ -1,14 +1,16 @@
 package com.example.devnote.processor_service.service;
 
 import com.example.devnote.processor_service.es.EsContent;
-import com.example.devnote.processor_service.es.EsContentRepository;
 import com.example.devnote.processor_service.es.EsSearchLog;
 import com.example.devnote.processor_service.es.EsSearchLogRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.query.Query;
@@ -29,30 +31,70 @@ public class ContentSearchService {
     /**
      * 키워드로 콘텐츠를 검색하고, IP기반으로 10분에 한 번씩 검색어 로그 남기기
      */
-    public Page<EsContent> search(String keyword, Pageable pageable, HttpServletRequest request) {
+    public Page<EsContent> search(String keyword, String source, String category, String sortOption, Pageable pageable, HttpServletRequest request) {
         // 검색어 로깅 시도
         logSearchQuery(keyword, request);
 
-        // 'title', 'description', 'channelTitle' 필드에서 키워드를 검색하는 쿼리를 생성
+        Sort sort = buildSort(sortOption);
+        Pageable finalPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+
+        // Bool 쿼리 구조를 must와 filter로 분리
         Query query = NativeQuery.builder()
                 .withQuery(q -> q
-                        .multiMatch(mm -> mm
-                                .query(keyword)
-                                .fields("title", "description", "channelTitle")
-                        )
+                        .bool(b -> {
+                            // 1. 점수 계산에 영향을 주는 검색어 쿼리는 'must' 절에 삽입
+                            b.must(m -> m
+                                    .multiMatch(mm -> mm
+                                            .query(keyword)
+                                            .fields("title", "description", "channelTitle")
+                                    )
+                            );
+
+                            // 2. 점수 계산 없이 필터링만 하는 조건들은 'filter' 절에 삽입
+                            b.filter(f -> f
+                                    .term(t -> t
+                                            .field("source")
+                                            .value(source.toUpperCase())
+                                    )
+                            );
+
+                            // 3. category 파라미터가 있을 경우에만 category 필터 조건을 추가
+                            if (category != null && !category.isBlank()) {
+                                b.filter(f -> f
+                                        .term(t -> t
+                                                .field("category")
+                                                .value(category)
+                                        )
+                                );
+                            }
+
+                            return b;
+                        })
                 )
-                .withPageable(pageable)
+                .withPageable(finalPageable)
                 .build();
 
-        // 쿼리 실행
         SearchHits<EsContent> searchHits = elasticsearchOperations.search(query, EsContent.class);
 
-        // SearchHits를 Page 객체로 변환 후 반환
         return org.springframework.data.support.PageableExecutionUtils.getPage(
                 searchHits.getSearchHits().stream().map(org.springframework.data.elasticsearch.core.SearchHit::getContent).toList(),
-                pageable,
+                finalPageable,
                 searchHits::getTotalHits
         );
+    }
+
+
+    /**
+     * 파라미터 값에 따라 Sort 객체를 생성하는 메서드
+     */
+    private Sort buildSort(String sortOption) {
+        return switch (sortOption.toLowerCase()) {
+            case "newest" -> Sort.by(Sort.Direction.DESC, "publishedAt");
+            case "oldest" -> Sort.by(Sort.Direction.ASC, "publishedAt");
+
+            // relevance(정확도순)일 경우, 정렬 없음을 명시하면 Elasticsearch 기본값인 연관도 점수(_score)로 정렬
+            default -> Sort.unsorted();
+        };
     }
 
     /**


### PR DESCRIPTION
- `ContentSearchController`: `source`(필수)와 `category`(선택), `sort`(선택)요청 파라미터를 받도록 수정했습니다.
- `ContentSearchService`: Elasticsearch 쿼리 생성 로직을 수정하여, `bool` 쿼리의 `filter` 절을 사용해 source와 category, sort 필터링을 수행하도록 개선했습니다.
  - `filter` 절을 사용하여 검색 점수(score)에 영향을 주지 않고 결과를 필터링합니다.