### PR TITLE
refactor: OAuth2 사용자 처리 로직 리팩토링 및 안정성 강화

### DIFF
--- a/user-service/src/main/java/com/example/devnote/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/example/devnote/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.devnote.config;
 
 import com.example.devnote.security.CustomOAuth2UserService;
+import com.example.devnote.security.CustomOidcUserService;
 import com.example.devnote.security.OAuth2AuthenticationFailureHandler;
 import com.example.devnote.security.OAuth2AuthenticationSuccessHandler;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtFilter;
     private final JwtRefreshFilter refreshFilter;
     private final CustomOAuth2UserService oauth2UserService;
+    private final CustomOidcUserService oidcUserService;
     private final OAuth2AuthenticationSuccessHandler successHandler;
     private final OAuth2AuthenticationFailureHandler failureHandler;
 
@@ -51,7 +53,10 @@ public class SecurityConfig {
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(a -> a.baseUri("/oauth2/authorize"))
                         .redirectionEndpoint(r -> r.baseUri("/login/oauth2/code/*"))
-                        .userInfoEndpoint(u -> u.userService(oauth2UserService))
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(oauth2UserService)   // 일반 OAuth2.0 용
+                                .oidcUserService(oidcUserService) // OIDC 용
+                        )
                         .successHandler(successHandler)
                         .failureHandler(failureHandler)
                 )

--- a/user-service/src/main/java/com/example/devnote/security/CustomOAuth2UserService.java
+++ b/user-service/src/main/java/com/example/devnote/security/CustomOAuth2UserService.java
@@ -1,67 +1,36 @@
 package com.example.devnote.security;
 
-import com.example.devnote.entity.User;
-import com.example.devnote.entity.WithdrawnUser;
-import com.example.devnote.exception.UserWithdrawnException;
-import com.example.devnote.repository.UserRepository;
-import com.example.devnote.repository.WithdrawnUserRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
-import java.time.Instant;
-import java.util.Optional;
-
 /**
- * OAuth2 로그인 후 사용자 정보 저장·업데이트
+ * 표준 OAuth 2.0 제공자(네이버, 카카오 등)의 사용자 정보를 처리하는 서비스
  */
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
-    private final UserRepository userRepo;
-    private final WithdrawnUserRepository withdrawnUserRepo;
 
+    private final OAuth2UserProcessor userProcessor;
+
+    /**
+     * OAuth2 제공자로부터 액세스 토큰을 받은 후 호출
+     * 이 메소드에서 사용자 정보를 가져와 DB에 저장하거나 업데이트
+     */
     @Override
-    public OAuth2User loadUser(OAuth2UserRequest req) {
-        OAuth2User user = super.loadUser(req);
-        var info = OAuth2UserInfoFactory.get(
-                req.getClientRegistration().getRegistrationId(),
-                user.getAttributes()
-        );
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 1. 부모 클래스의 loadUser를 호출하여 기본적인 OAuth2User 객체를 가져옴
+        OAuth2User oauth2User = super.loadUser(userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
 
-        // 재가입 방지 로직
-        withdrawnUserRepo.findByEmail(info.getEmail()).ifPresent(withdrawnUser -> {
-            if (withdrawnUser.getCanRejoinAt().isAfter(Instant.now())) {
-                log.warn("탈퇴 후 7일이 경과하지 않은 사용자의 로그인 시도: {}", info.getEmail());
-                // 커스텀 예외를 발생시켜 FailureHandler로 제어를 넘김
-                throw new UserWithdrawnException(info.getEmail());
-            } else {
-                withdrawnUserRepo.delete(withdrawnUser);
-                log.info("재가입 방지 기간이 만료되어 탈퇴 기록 삭제: {}", info.getEmail());
-            }
-        });
+        // 2. 중앙 관리되는 userProcessor를 통해 사용자 정보를 처리 (가입/업데이트)
+        var user = userProcessor.processUser(registrationId, oauth2User);
 
-        User entity = userRepo.findByProviderAndProviderId(
-                req.getClientRegistration().getRegistrationId(), info.getId()
-        ).orElseGet(() -> User.builder()
-                .provider(req.getClientRegistration().getRegistrationId())
-                .providerId(info.getId())
-                .email(info.getEmail())
-                .name(info.getName())
-                .picture(info.getImageUrl())
-                .build()
-        );
-
-        // 최신 정보로 갱신
-        entity.setName(info.getName());
-        entity.setPicture(info.getImageUrl());
-        userRepo.save(entity);
-
-        return user;
+        // 3. 처리된 User 엔티티와 원본 oauth2User 정보를 담은 PrincipalDetails 객체를 생성하여 반환
+        // 이 반환된 객체가 Spring Security의 SecurityContext에 저장됨
+        return new PrincipalDetails(user, oauth2User);
     }
 }

--- a/user-service/src/main/java/com/example/devnote/security/CustomOidcUserService.java
+++ b/user-service/src/main/java/com/example/devnote/security/CustomOidcUserService.java
@@ -1,0 +1,36 @@
+package com.example.devnote.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+
+/**
+ * OIDC(OpenID Connect) 1.0 제공자(구글 등)의 사용자 정보를 처리하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class CustomOidcUserService extends OidcUserService {
+
+    private final OAuth2UserProcessor userProcessor;
+
+    /**
+     * OIDC 제공자로부터 ID 토큰을 받은 후 호출
+     * 이 메소드에서 사용자 정보를 가져와 DB에 저장하거나 업데이트
+     */
+    @Override
+    public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+        // 1. 부모 클래스의 loadUser를 호출하여 기본적인 OidcUser 객체를 가져옴
+        OidcUser oidcUser = super.loadUser(userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        // 2. 중앙 관리되는 userProcessor를 통해 사용자 정보를 처리 (가입/업데이트)
+        var user = userProcessor.processUser(registrationId, oidcUser);
+
+        // 3. 처리된 User 엔티티와 원본 oidcUser 정보를 담은 PrincipalDetails 객체를 생성하여 반환
+        // 이 반환된 객체가 Spring Security의 SecurityContext에 저장됨
+        return new PrincipalDetails(user, oidcUser);
+    }
+}

--- a/user-service/src/main/java/com/example/devnote/security/OAuth2UserProcessor.java
+++ b/user-service/src/main/java/com/example/devnote/security/OAuth2UserProcessor.java
@@ -1,0 +1,65 @@
+package com.example.devnote.security;
+
+import com.example.devnote.entity.User;
+import com.example.devnote.exception.UserWithdrawnException;
+import com.example.devnote.repository.UserRepository;
+import com.example.devnote.repository.WithdrawnUserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2UserProcessor {
+
+    private final UserRepository userRepo;
+    private final WithdrawnUserRepository withdrawnUserRepo;
+
+    @Value("${app.default-profile-image-url:/images/default-avatar.png}")
+    private String defaultProfileImageUrl;
+
+    @Transactional
+    public User processUser(String registrationId, OAuth2User oauth2User) {
+        var info = OAuth2UserInfoFactory.get(registrationId, oauth2User.getAttributes());
+
+        // 재가입 방지 로직
+        withdrawnUserRepo.findByEmail(info.getEmail()).ifPresent(withdrawnUser -> {
+            if (withdrawnUser.getCanRejoinAt().isAfter(Instant.now())) {
+                log.warn("탈퇴 후 7일이 경과하지 않은 사용자의 로그인 시도: {}", info.getEmail());
+                throw new UserWithdrawnException(info.getEmail());
+            } else {
+                withdrawnUserRepo.delete(withdrawnUser);
+                log.info("재가입 방지 기간이 만료되어 탈퇴 기록 삭제: {}", info.getEmail());
+            }
+        });
+
+        // 제공자 정보와 제공자 내부의 고유 ID로 사용자를 조회
+        String providerId = info.getId();
+        String provider = registrationId;
+
+        User entity = userRepo.findByProviderAndProviderId(provider, providerId)
+                // 이미 가입된 사용자인 경우: 이름(닉네임) 정보 업데이트
+                .map(existingUser -> {
+                    existingUser.setName(info.getName());
+                    return existingUser;
+                })
+                // 새로 가입하는 사용자인 경우: User 엔티티를 생성하여 DB에 저장
+                .orElseGet(() -> {
+                    return User.builder()
+                            .provider(provider)
+                            .providerId(providerId)
+                            .email(info.getEmail())
+                            .name(info.getName())
+                            .picture(defaultProfileImageUrl)
+                            .build();
+                });
+
+        return userRepo.save(entity);
+    }
+}

--- a/user-service/src/main/java/com/example/devnote/security/PrincipalDetails.java
+++ b/user-service/src/main/java/com/example/devnote/security/PrincipalDetails.java
@@ -1,0 +1,66 @@
+package com.example.devnote.security;
+
+import com.example.devnote.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Spring Security의 인증 주체(Principal)로 사용될 커스텀 클래스
+ */
+@Getter
+public class PrincipalDetails implements OAuth2User, OidcUser {
+
+    private final User user;
+    private final OAuth2User oauth2User; // 원본 OAuth2User 또는 OidcUser 저장
+
+    public PrincipalDetails(User user, OAuth2User oauth2User) {
+        this.user = user;
+        this.oauth2User = oauth2User;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return oauth2User.getAttributes();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return oauth2User.getAuthorities();
+    }
+
+    @Override
+    public String getName() {
+        return user.getProviderId();
+    }
+
+    @Override
+    public Map<String, Object> getClaims() {
+        if (oauth2User instanceof OidcUser) {
+            return ((OidcUser) oauth2User).getClaims();
+        }
+        return null;
+    }
+
+    @Override
+    public OidcUserInfo getUserInfo() {
+        if (oauth2User instanceof OidcUser) {
+            return ((OidcUser) oauth2User).getUserInfo();
+        }
+        return null;
+    }
+
+    @Override
+    public OidcIdToken getIdToken() {
+        if (oauth2User instanceof OidcUser) {
+            return ((OidcUser) oauth2User).getIdToken();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
- **`OAuth2UserProcessor` 도입**: `CustomOidcUserService`(Google)와 `CustomOAuth2UserService`(Naver, Kakao)가 호출하는 사용자 처리 로직을 이 클래스로 중앙화하여 중복을 제거하고 역할을 명확히 했습니다.
- **`PrincipalDetails` 구현**: `OAuth2UserProcessor`가 처리한 최종 `User` 엔티티를 `PrincipalDetails` 객체에 담아 Spring Security Context를 통해 전달합니다.
- **`SuccessHandler` 역할 단순화**: `OAuth2AuthenticationSuccessHandler`는 더 이상 DB를 조회하지 않고, `PrincipalDetails`에서 `User` 객체를 직접 꺼내 JWT 발급만 담당하도록 수정하여 데이터 정합성 문제를 원천적으로 해결했습니다.