### PR TITLE
feat: 프로필 사진 변경 및 초기화 기능 구현

### DIFF
--- a/user-service/src/main/java/com/example/devnote/config/WebConfig.java
+++ b/user-service/src/main/java/com/example/devnote/config/WebConfig.java
@@ -10,6 +10,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Value("${file.upload-dir}")
     private String uploadDir;
 
+    @Value("${file.profile-upload-dir}")
+    private String profileUploadDir;
+
     /**
      * 정적 리소스 핸들러를 추가하여 URL과 실제 파일 경로를 매핑
      */
@@ -19,5 +22,10 @@ public class WebConfig implements WebMvcConfigurer {
         // 서버의 실제 물리 경로인 file:./uploads/inquiries/some-file.jpg 파일을 찾아서 제공
         registry.addResourceHandler("/images/inquiries/**")
                 .addResourceLocations("file:" + uploadDir + "/");
+
+        // /images/profile/ 로 시작하는 URL 요청이 오면
+        // file:./uploads/profile/ 경로에서 파일을 찾아 반환
+        registry.addResourceHandler("/images/profile/**")
+                .addResourceLocations("file:" + profileUploadDir + "/");
     }
 }

--- a/user-service/src/main/java/com/example/devnote/controller/ProfileController.java
+++ b/user-service/src/main/java/com/example/devnote/controller/ProfileController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -97,6 +98,42 @@ public class ProfileController {
                         .message("Fetched withdrawn user info successfully.")
                         .statusCode(HttpStatus.OK.value())
                         .data(withdrawnInfoDto)
+                        .build()
+        );
+    }
+
+    /**
+     * 현재 로그인된 사용자의 프로필 사진을 변경
+     * @param imageFile 새로 업로드할 이미지 파일 (multipart/form-data)
+     */
+    @PostMapping("/me/profile-image")
+    public ResponseEntity<ApiResponseDto<ProfileImageResponseDto>> updateProfileImage(
+            @RequestParam("image") MultipartFile imageFile) {
+
+        ProfileImageResponseDto responseDto = profileService.updateProfileImage(imageFile);
+
+        return ResponseEntity.ok(
+                ApiResponseDto.<ProfileImageResponseDto>builder()
+                        .message("프로필 사진이 성공적으로 변경되었습니다.")
+                        .statusCode(HttpStatus.OK.value())
+                        .data(responseDto)
+                        .build()
+        );
+    }
+
+    /**
+     * 현재 로그인된 사용자의 프로필 사진을 기본 이미지로 초기화
+     */
+    @DeleteMapping("/me/profile-image")
+    public ResponseEntity<ApiResponseDto<ProfileImageResponseDto>> resetProfileImage() {
+
+        ProfileImageResponseDto responseDto = profileService.resetProfileImage();
+
+        return ResponseEntity.ok(
+                ApiResponseDto.<ProfileImageResponseDto>builder()
+                        .message("프로필 사진이 기본 이미지로 초기화되었습니다.")
+                        .statusCode(HttpStatus.OK.value())
+                        .data(responseDto)
                         .build()
         );
     }

--- a/user-service/src/main/java/com/example/devnote/dto/ProfileImageResponseDto.java
+++ b/user-service/src/main/java/com/example/devnote/dto/ProfileImageResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.devnote.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProfileImageResponseDto {
+    private String pictureUrl;
+}

--- a/user-service/src/main/java/com/example/devnote/service/FileStorageService.java
+++ b/user-service/src/main/java/com/example/devnote/service/FileStorageService.java
@@ -1,5 +1,6 @@
 package com.example.devnote.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -16,46 +17,56 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * 서버에 파일을 저장하고 관리하는 역할을 전담하는 범용 서비스
+ */
 @Service
+@Slf4j
 public class FileStorageService {
 
-    private final Path fileStorageLocation; // 파일이 저장될 실제 경로
-    private final long maxFileSize;         // 허용되는 파일의 최대 크기
+    // 업로드 파일이 저장될 최상위 기본 경로를 설정
+    private final Path fileStorageRootLocation;
+    private final long maxFileSize;
 
     // 허용할 이미지 파일의 MIME 타입 목록
     private static final List<String> ALLOWED_IMAGE_CONTENT_TYPES = Arrays.asList("image/jpeg", "image/png", "image/gif");
 
     /**
      * 생성자
-     * @param uploadDir 파일 저장 디렉터리 경로
      * @param maxFileSizeStr 파일 최대 크기 (문자열, 예: "10MB")
      */
-    public FileStorageService(@Value("${file.upload-dir}") String uploadDir,
-                              @Value("${spring.servlet.multipart.max-file-size}") String maxFileSizeStr) {
-
-        // 1. 파일 저장 위치(Path 객체)를 설정
-        this.fileStorageLocation = Paths.get(uploadDir).toAbsolutePath().normalize();
-        // 2. '10MB'와 같은 문자열을 long 타입의 바이트로 변환
+    public FileStorageService(@Value("${spring.servlet.multipart.max-file-size}") String maxFileSizeStr) {
+        this.fileStorageRootLocation = Paths.get("./uploads").toAbsolutePath().normalize();
         this.maxFileSize = parseSize(maxFileSizeStr);
 
         try {
-            // 3. 서버 시작 시 파일 저장 디렉터리가 없으면 자동으로 생성
-            Files.createDirectories(this.fileStorageLocation);
+            // 서버 시작 시 기본 업로드 폴더가 없으면 생성
+            Files.createDirectories(this.fileStorageRootLocation);
         } catch (Exception ex) {
             throw new RuntimeException("파일을 업로드할 디렉터리를 생성할 수 없습니다.", ex);
         }
     }
 
     /**
-     * 파일을 유효성 검사 후 저장하고, 서버에서 접근 가능한 URL 경로를 반환
+     * 파일을 지정된 하위 디렉터리에 저장하고, 서버에서 접근 가능한 URL 경로를 반환
      * @param file 저장할 MultipartFile
-     * @return 저장된 파일의 접근 URL (예: /images/inquiries/uuid-filename.jpg)
+     * @param subDirectory 저장할 하위 폴더 (예: "inquiries", "profile")
+     * @return 저장된 파일의 접근 URL (예: /images/profile/uuid-filename.jpg)
      */
-    public String storeFile(MultipartFile file) {
-        // 1. 파일 유효성 검사를 먼저 수행
+    public String storeFile(MultipartFile file, String subDirectory) {
+        // 1. 파일 유효성 검사
         validateFile(file);
 
-        // 2. 원본 파일 이름에서 확장자를 추출하고, 고유한 파일명을 생성
+        // 2. 하위 폴더를 포함한 전체 저장 경로를 설정. (예: ./uploads/profile)
+        Path storageDirectory = this.fileStorageRootLocation.resolve(subDirectory).normalize();
+        try {
+            // 하위 폴더가 없으면 생성
+            Files.createDirectories(storageDirectory);
+        } catch (Exception ex) {
+            throw new RuntimeException("하위 디렉터리를 생성할 수 없습니다.", ex);
+        }
+
+        // 3. 파일 이름에서 확장자를 추출하고, 중복되지 않는 고유한 파일명을 생성
         String originalFileName = StringUtils.cleanPath(file.getOriginalFilename());
         String fileExtension;
         try {
@@ -68,16 +79,36 @@ public class FileStorageService {
         }
         String storedFileName = UUID.randomUUID().toString() + fileExtension;
 
-        // 3. 파일을 실제로 디스크에 저장
+        // 4. 파일을 실제로 디스크에 저장
         try {
-            Path targetLocation = this.fileStorageLocation.resolve(storedFileName);
+            Path targetLocation = storageDirectory.resolve(storedFileName);
             Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException ex) {
             throw new RuntimeException(storedFileName + " 파일을 저장할 수 없습니다. 다시 시도해주세요.", ex);
         }
 
-        // 4. 외부에서 접근 가능한 최종 URL 경로를 반환
-        return "/images/inquiries/" + storedFileName;
+        // 5. 외부에서 접근 가능한 최종 URL 경로를 반환 (예: /images/profile/uuid-filename.jpg)
+        return "/images/" + subDirectory + "/" + storedFileName;
+    }
+
+    /**
+     * 서버에 저장된 파일을 URL 경로를 기반으로 삭제합니다.
+     * @param fileUrl 삭제할 파일의 URL (예: /images/profile/uuid-name.jpg)
+     */
+    public void deleteFile(String fileUrl) {
+        // 기본 이미지 경로는 삭제하지 않도록 예외 처리
+        if (fileUrl == null || fileUrl.isBlank() || !fileUrl.startsWith("/images/")) {
+            return;
+        }
+        try {
+            // URL 경로에서 실제 파일 시스템 경로를 계산
+            // 예: /images/profile/some-file.jpg -> ./uploads/profile/some-file.jpg
+            String relativePath = fileUrl.substring("/images/".length());
+            Path targetLocation = this.fileStorageRootLocation.resolve(relativePath).toAbsolutePath().normalize();
+            Files.deleteIfExists(targetLocation);
+        } catch (Exception e) {
+            log.error("파일 삭제에 실패했습니다: {}", fileUrl, e);
+        }
     }
 
     /**
@@ -108,20 +139,5 @@ public class FileStorageService {
             return Long.parseLong(size.substring(0, size.length() - 2)) * 1024;
         }
         return Long.parseLong(size);
-    }
-
-    /**
-     * 서버에 저장된 파일 삭제
-     * @param fileUrl 삭제할 파일의 URL (예: /images/inquiries/uuid-name.jpg)
-     */
-    public void deleteFile(String fileUrl) {
-        try {
-            String fileName = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
-            Path targetLocation = this.fileStorageLocation.resolve(fileName);
-            Files.deleteIfExists(targetLocation);
-        } catch (Exception e) {
-            System.err.println("파일 삭제에 실패했습니다: " + fileUrl);
-            e.printStackTrace();
-        }
     }
 }

--- a/user-service/src/main/java/com/example/devnote/service/InquiryService.java
+++ b/user-service/src/main/java/com/example/devnote/service/InquiryService.java
@@ -46,7 +46,7 @@ public class InquiryService {
      * @return 서버에 저장된 후의 접근 URL
      */
     public String uploadImage(MultipartFile imageFile) {
-        return fileStorageService.storeFile(imageFile);
+        return fileStorageService.storeFile(imageFile, "inquiries");
     }
 
     /**

--- a/user-service/src/main/java/com/example/devnote/service/NoticeService.java
+++ b/user-service/src/main/java/com/example/devnote/service/NoticeService.java
@@ -55,7 +55,7 @@ public class NoticeService {
     public String uploadImage(MultipartFile imageFile) {
         // 관리자만 이미지 업로드가 가능하도록 권한 확인
         getAdminUser();
-        return fileStorageService.storeFile(imageFile);
+        return fileStorageService.storeFile(imageFile, "inquiries");
     }
 
     /**


### PR DESCRIPTION
- **ProfileController**: 프로필 사진을 업로드하는 `POST /me/profile-image`와 기본값으로 초기화하는 `DELETE /me/profile-image` API 엔드포인트를 추가했습니다.
- **UserProfileService**: 새 이미지 저장, 서버에 저장된 이전 파일 삭제, DB 업데이트 등 실제 프로필 사진 변경 및 초기화 로직을 구현했습니다.
- **FileStorageService**: 문의사항과 프로필 사진을 각각 다른 하위 폴더('inquiries', 'profile')에 저장할 수 있도록, `storeFile`과 `deleteFile` 메서드를 범용적으로 리팩토링했습니다.
- **WebConfig 및 application.yml**: 프로필 사진이 저장될 경로(`file.profile-upload-dir`)를 설정하고, 해당 경로의 이미지에 외부에서 접근할 수 있도록 리소스 핸들러를 추가했습니다.