### PR TITLE
feat: 검색어 자동 완성 기능 구현

### DIFF
--- a/processor-service/src/main/java/com/example/devnote/processor_service/controller/ContentSearchController.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/controller/ContentSearchController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/contents/search")
@@ -45,6 +47,26 @@ public class ContentSearchController {
                         .message("Content search successful")
                         .statusCode(200)
                         .data(result)
+                        .build()
+        );
+    }
+
+    /**
+     * 검색어 자동 완성 API
+     * @param q 사용자가 입력 중인 키워드
+     * @param source 검색할 소스 (YOUTUBE 또는 NEWS)
+     * @return 추천 검색어 목록
+     */
+    @GetMapping("/suggest")
+    public ResponseEntity<ApiResponseDto<List<String>>> suggest(
+            @RequestParam("q") String q,
+            @RequestParam("source") String source) {
+        List<String> suggestions = contentSearchService.getSuggestions(q, source);
+        return ResponseEntity.ok(
+                ApiResponseDto.<List<String>>builder()
+                        .message("Fetched search suggestions")
+                        .statusCode(200)
+                        .data(suggestions)
                         .build()
         );
     }

--- a/processor-service/src/main/java/com/example/devnote/processor_service/es/EsContent.java
+++ b/processor-service/src/main/java/com/example/devnote/processor_service/es/EsContent.java
@@ -18,8 +18,11 @@ public class EsContent {
     private Long id;
 
     @MultiField(
-            mainField = @Field(type = FieldType.Text, analyzer = "korean_analyzer"), // (1) 전문 검색용 (형태소 분석)
-            otherFields = { @InnerField(suffix = "keyword", type = FieldType.Keyword) } // (2) 정확한 값 정렬/집계용
+            mainField = @Field(type = FieldType.Text, analyzer = "korean_analyzer"),
+            otherFields = {
+                    @InnerField(suffix = "keyword", type = FieldType.Keyword),
+                    @InnerField(suffix = "suggest", type = FieldType.Search_As_You_Type, analyzer = "korean_analyzer")
+            }
     )
     private String title;
 


### PR DESCRIPTION
- **Elasticsearch 매핑**: `contents` 인덱스의 `title` 필드에 자동 완성을 위한 `suggest` 하위 필드(`search_as_you_type`)를 추가했습니다.
- **EsContent.java**: 변경된 매핑을 Spring Data Elasticsearch가 인식하도록 `@MultiField` 어노테이션을 수정했습니다.
- **ContentSearchService**: `title.suggest` 필드를 `bool_prefix` 쿼리로 조회하여 추천 검색어 목록을 반환하는 `getSuggestions` 메서드를 추가했습니다.
- **ContentSearchController**: `GET /api/v1/contents/search/suggest` API 엔드포인트를 추가하여 자동 완성 기능을 외부에 제공합니다.