### PR TITLE
feat: 사용자 콘텐츠 시청 기록 기능 추가

### DIFF
--- a/user-service/src/main/java/com/example/devnote/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/example/devnote/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
                         .requestMatchers("/oauth2/**", "/login/**", "/api/v1/auth/**", "/api/v1/comments/**", "/internal/**", "/api/v1/inquiries/**")
                         .permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/notices", "/api/v1/notices/**").permitAll()
-                        .requestMatchers("/api/v1/users/*/profile").permitAll()
+                        .requestMatchers("/api/v1/users/**").permitAll()
                         .requestMatchers("/api/v1/users/withdrawn-info").permitAll()
                         .requestMatchers("/api/v1/users/reports/**").permitAll()
                         .anyRequest().authenticated()

--- a/user-service/src/main/java/com/example/devnote/controller/HistoryController.java
+++ b/user-service/src/main/java/com/example/devnote/controller/HistoryController.java
@@ -1,0 +1,51 @@
+package com.example.devnote.controller;
+
+import com.example.devnote.dto.ApiResponseDto;
+import com.example.devnote.dto.ContentDto;
+import com.example.devnote.dto.ViewHistoryRequestDto;
+import com.example.devnote.service.HistoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/users/history")
+@RequiredArgsConstructor
+public class HistoryController {
+
+    private final HistoryService historyService;
+
+    /**
+     * 시청 기록을 저장(또는 업데이트)
+     */
+    @PostMapping("/view")
+    public ResponseEntity<ApiResponseDto<Void>> recordView(@Valid @RequestBody ViewHistoryRequestDto requestDto) {
+        historyService.recordViewHistory(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponseDto.<Void>builder()
+                        .message("시청 기록이 저장되었습니다.")
+                        .statusCode(HttpStatus.CREATED.value())
+                        .build());
+    }
+
+    /**
+     * 현재 로그인된 사용자의 시청 기록 목록을 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponseDto<Page<ContentDto>>> getHistory(
+            @PageableDefault(size = 20) Pageable pageable) {
+        Page<ContentDto> historyPage = historyService.getViewHistory(pageable);
+        return ResponseEntity.ok(
+                ApiResponseDto.<Page<ContentDto>>builder()
+                        .message("시청 기록을 조회했습니다.")
+                        .statusCode(HttpStatus.OK.value())
+                        .data(historyPage)
+                        .build()
+        );
+    }
+}

--- a/user-service/src/main/java/com/example/devnote/dto/ViewHistoryRequestDto.java
+++ b/user-service/src/main/java/com/example/devnote/dto/ViewHistoryRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.devnote.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class ViewHistoryRequestDto {
+    @NotNull(message = "콘텐츠 ID는 필수입니다.")
+    private Long contentId;
+}

--- a/user-service/src/main/java/com/example/devnote/entity/ViewHistory.java
+++ b/user-service/src/main/java/com/example/devnote/entity/ViewHistory.java
@@ -1,0 +1,43 @@
+package com.example.devnote.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+/**
+ * 사용자의 콘텐츠 시청 기록을 저장하는 엔티티
+ * 한 사용자는 하나의 콘텐츠에 대해 하나의 시청 기록만 가집니다. (재시청 시 시간만 업데이트)
+ */
+@Entity
+@Table(name = "view_history",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "content_id"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ViewHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /**
+     * 시청한 콘텐츠의 ID
+     */
+    @Column(name = "content_id", nullable = false)
+    private Long contentId;
+
+    /**
+     * 마지막으로 시청한 시각
+     */
+    @UpdateTimestamp
+    @Column(name = "viewed_at", nullable = false)
+    private Instant viewedAt;
+}

--- a/user-service/src/main/java/com/example/devnote/repository/ViewHistoryRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/ViewHistoryRepository.java
@@ -1,0 +1,22 @@
+package com.example.devnote.repository;
+
+import com.example.devnote.entity.User;
+import com.example.devnote.entity.ViewHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ViewHistoryRepository extends JpaRepository<ViewHistory, Long> {
+
+    /**
+     * 사용자와 콘텐츠 ID로 기존 시청 기록 조회 (업데이트용)
+     */
+    Optional<ViewHistory> findByUserAndContentId(User user, Long contentId);
+
+    /**
+     * 사용자의 전체 시청 기록을 마지막 시청 시간(viewedAt)의 내림차순으로 페이지네이션하여 조회
+     */
+    Page<ViewHistory> findByUserOrderByViewedAtDesc(User user, Pageable pageable);
+}

--- a/user-service/src/main/java/com/example/devnote/service/HistoryService.java
+++ b/user-service/src/main/java/com/example/devnote/service/HistoryService.java
@@ -1,0 +1,119 @@
+package com.example.devnote.service;
+
+import com.example.devnote.dto.ApiResponseDto;
+import com.example.devnote.dto.ContentDto;
+import com.example.devnote.dto.ViewHistoryRequestDto;
+import com.example.devnote.entity.User;
+import com.example.devnote.entity.ViewHistory;
+import com.example.devnote.repository.UserRepository;
+import com.example.devnote.repository.ViewHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class HistoryService {
+
+    private final ViewHistoryRepository historyRepository;
+    private final UserRepository userRepository;
+    private final WebClient apiGatewayClient;
+
+    /**
+     * 현재 로그인된 사용자의 시청 기록을 저장하거나 업데이트
+     */
+    @Transactional
+    public void recordViewHistory(ViewHistoryRequestDto dto) {
+        User currentUser = getCurrentUser();
+        Long contentId = dto.getContentId();
+
+        // 1. 동일한 콘텐츠에 대한 시청 기록이 이미 있는지 확인
+        ViewHistory history = historyRepository.findByUserAndContentId(currentUser, contentId)
+                .map(existingHistory -> {
+                    // 2. 기존 기록이 있다면, viewedAt 시간을 현재 시간으로 업데이트
+                    existingHistory.setViewedAt(Instant.now());
+                    return existingHistory;
+                })
+                .orElseGet(() -> ViewHistory.builder() // 3. 없다면 새로 생성
+                        .user(currentUser)
+                        .contentId(contentId)
+                        .build());
+
+        // 4. save를 호출하면, 새 기록은 INSERT 기존 기록은 UPDATE
+        historyRepository.save(history);
+    }
+
+    /**
+     * 현재 로그인된 사용자의 시청 기록 목록을 조회합니다.
+     * 존재하지 않는 콘텐츠의 기록은 자동으로 삭제
+     */
+    @Transactional
+    public Page<ContentDto> getViewHistory(Pageable pageable) {
+        User currentUser = getCurrentUser();
+        Page<ViewHistory> historyPage = historyRepository.findByUserOrderByViewedAtDesc(currentUser, pageable);
+
+        List<ContentDto> validContents = new ArrayList<>();
+        List<ViewHistory> historiesToDelete = new ArrayList<>();
+
+        for (ViewHistory history : historyPage.getContent()) {
+            ContentDto content = fetchContentDetails(history.getContentId());
+
+            if (content != null) {
+                // 콘텐츠 정보 조회를 성공하면, 유효한 목록에 추가
+                validContents.add(content);
+            } else {
+                // 콘텐츠 정보 조회를 실패하면(삭제된 콘텐츠), 해당 시청 기록을 삭제 대상 목록에 추가
+                historiesToDelete.add(history);
+            }
+        }
+
+        // 삭제 대상이 있다면 DB에서 한 번에 삭제
+        if (!historiesToDelete.isEmpty()) {
+            historyRepository.deleteAllInBatch(historiesToDelete);
+            log.info("존재하지 않는 콘텐츠에 대한 시청 기록 {}건을 삭제했습니다.", historiesToDelete.size());
+        }
+
+        return new PageImpl<>(validContents, pageable, historyPage.getTotalElements() - historiesToDelete.size());
+    }
+
+    private User getCurrentUser() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."));
+    }
+
+    /**
+     * 콘텐츠 상세 정보를 조회하고, 404 Not Found 발생 시 null을 반환
+     */
+    private ContentDto fetchContentDetails(Long contentId) {
+        try {
+            ApiResponseDto<ContentDto> response = apiGatewayClient.get()
+                    .uri("/api/v1/contents/{id}", contentId)
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<ApiResponseDto<ContentDto>>() {})
+                    .block();
+            return (response != null) ? response.getData() : null;
+        } catch (WebClientResponseException.NotFound ex) {
+            log.warn("시청 기록에 포함된 콘텐츠 정보를 찾을 수 없습니다 (contentId={}).", contentId);
+            return null;
+        } catch (Exception e) {
+            log.error("콘텐츠 정보를 가져오는 중 오류 발생 (contentId={})", contentId, e);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
- **시청 기록 저장**: `POST /api/v1/users/history/view` API를 통해 시청 기록을 저장합니다. 사용자가 동일한 콘텐츠를 다시 시청할 경우, `viewed_at` 시간을 최신으로 업데이트하여 목록의 맨 위로 이동시킵니다.
- **시청 기록 조회**: `GET /api/v1/users/history` API를 통해 사용자의 시청 기록을 최신순으로 페이지네이션하여 조회합니다.
- **데이터 자동 정리**: 시청 기록 조회 시, 원본 콘텐츠가 삭제되어 404 오류가 발생하는 경우, 해당 시청 기록을 DB에서 자동으로 삭제하여 데이터 정합성을 유지합니다.
- **엔티티 및 리포지토리**: 시청 기록을 관리하기 위한 `ViewHistory` 엔티티와 `ViewHistoryRepository`를 추가했습니다.