### PR TITLE
feat: 시청 기록 삭제 기능 추가

### DIFF
--- a/eureka-server/build.gradle
+++ b/eureka-server/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot'
+id 'org.springframework.boot'
 	id 'io.spring.dependency-management'
 	id 'java'
 }

--- a/user-service/src/main/java/com/example/devnote/controller/HistoryController.java
+++ b/user-service/src/main/java/com/example/devnote/controller/HistoryController.java
@@ -48,4 +48,46 @@ public class HistoryController {
                         .build()
         );
     }
+
+    /**
+     * 특정 콘텐츠에 대한 시청 기록을 개별 삭제
+     * @param contentId 삭제할 콘텐츠의 ID
+     */
+    @DeleteMapping("/{contentId}")
+    public ResponseEntity<ApiResponseDto<Void>> deleteHistory(@PathVariable Long contentId) {
+        historyService.deleteHistoryByContentId(contentId);
+        return ResponseEntity.ok(
+                ApiResponseDto.<Void>builder()
+                        .message("선택한 시청 기록이 삭제되었습니다.")
+                        .statusCode(HttpStatus.OK.value())
+                        .build()
+        );
+    }
+
+    /**
+     * 특정 소스(YOUTUBE/NEWS)에 대한 모든 시청 기록을 삭제
+     * @param source "YOUTUBE" 또는 "NEWS"
+     */
+    @DeleteMapping
+    public ResponseEntity<ApiResponseDto<Void>> deleteAllHistory(@RequestParam String source) {
+        // source 파라미터가 유효한지 확인
+        if (!"YOUTUBE".equalsIgnoreCase(source) && !"NEWS".equalsIgnoreCase(source)) {
+            return ResponseEntity.badRequest().body(
+                    ApiResponseDto.<Void>builder()
+                            .message("source 파라미터는 YOUTUBE 또는 NEWS만 가능합니다.")
+                            .statusCode(HttpStatus.BAD_REQUEST.value())
+                            .build()
+            );
+        }
+
+        historyService.deleteAllHistory(source.toUpperCase());
+
+        String message = String.format("%s 시청 기록이 모두 삭제되었습니다.", source.toUpperCase());
+        return ResponseEntity.ok(
+                ApiResponseDto.<Void>builder()
+                        .message(message)
+                        .statusCode(HttpStatus.OK.value())
+                        .build()
+        );
+    }
 }

--- a/user-service/src/main/java/com/example/devnote/repository/ViewHistoryRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/ViewHistoryRepository.java
@@ -2,21 +2,35 @@ package com.example.devnote.repository;
 
 import com.example.devnote.entity.User;
 import com.example.devnote.entity.ViewHistory;
+import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ViewHistoryRepository extends JpaRepository<ViewHistory, Long> {
 
     /**
-     * 사용자와 콘텐츠 ID로 기존 시청 기록 조회 (업데이트용)
+     * 특정 사용자와 콘텐츠 ID로 기존 시청 기록 조회 (업데이트용)
      */
     Optional<ViewHistory> findByUserAndContentId(User user, Long contentId);
 
     /**
-     * 사용자의 전체 시청 기록을 마지막 시청 시간(viewedAt)의 내림차순으로 페이지네이션하여 조회
+     * 특정 사용자의 전체 시청 기록을 마지막 시청 시간(viewedAt)의 내림차순으로 페이지네이션하여 조회
      */
     Page<ViewHistory> findByUserOrderByViewedAtDesc(User user, Pageable pageable);
+
+    /**
+     * 특정 사용자의 모든 시청 기록을 리스트로 조회
+     */
+    List<ViewHistory> findByUser(User user);
+
+    /**
+     * 특정 사용자의 특정 콘텐츠에 대한 시청 기록 삭제
+     */
+    @Transactional
+    long deleteByUserAndContentId(User user, Long contentId);
 }
+


### PR DESCRIPTION
- **시청 기록 삭제 기능 추가**: `HistoryController`에 아래 두 개의 `DELETE` API를 추가했습니다.
- `DELETE /users/history/{contentId}`: 특정 콘텐츠 기록을 개별로 삭제합니다.
- `DELETE /users/history?source={YOUTUBE|NEWS}`: 'YOUTUBE' 또는 'NEWS' 소스에 해당하는 모든 기록을 전체 삭제합니다.