### PR TITLE
refactor: 키워드 검색 방식 제거 및 YAML 기반 채널 수집으로 변경

### DIFF
--- a/news-youtube-service/src/main/java/com/example/devnote/news_youtube_service/config/YouTubeProperties.java
+++ b/news-youtube-service/src/main/java/com/example/devnote/news_youtube_service/config/YouTubeProperties.java
@@ -1,0 +1,42 @@
+package com.example.devnote.news_youtube_service.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@ConfigurationProperties(prefix = "youtube")
+public class YouTubeProperties {
+
+    private List<Channel> channels;
+
+    public List<Channel> getChannels() {
+        return channels;
+    }
+
+    public void setChannels(List<Channel> channels) {
+        this.channels = channels;
+    }
+
+    /**
+     * 각 유튜브 채널의 설정을 담는 내부 정적 클래스
+     */
+    public static class Channel {
+        private String name;
+        private String channelId;
+
+        public String getName() {
+            return name;
+        }
+        public void setName(String name) {
+            this.name = name;
+        }
+        public String getChannelId() {
+            return channelId;
+        }
+        public void setChannelId(String channelId) {
+            this.channelId = channelId;
+        }
+    }
+}

--- a/news-youtube-service/src/main/java/com/example/devnote/news_youtube_service/repository/ChannelSubscriptionRepository.java
+++ b/news-youtube-service/src/main/java/com/example/devnote/news_youtube_service/repository/ChannelSubscriptionRepository.java
@@ -7,8 +7,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ChannelSubscriptionRepository extends JpaRepository<ChannelSubscription, Long> {
-    List<ChannelSubscription> findByInitialLoadedFalse();
-    List<ChannelSubscription> findByInitialLoadedTrue();
     Optional<ChannelSubscription> findByChannelId(String channelId);
     List<ChannelSubscription> findBySource(String source);
+    List<ChannelSubscription> findBySourceAndInitialLoadedFalse(String source);
+    List<ChannelSubscription> findBySourceAndInitialLoadedTrue(String source);
 }

--- a/news-youtube-service/src/main/java/com/example/devnote/news_youtube_service/service/ChannelMetadataService.java
+++ b/news-youtube-service/src/main/java/com/example/devnote/news_youtube_service/service/ChannelMetadataService.java
@@ -1,0 +1,130 @@
+package com.example.devnote.news_youtube_service.service;
+
+import com.example.devnote.news_youtube_service.entity.ChannelSubscription;
+import com.example.devnote.news_youtube_service.repository.ChannelSubscriptionRepository;
+import com.google.api.services.youtube.YouTube;
+import com.google.api.services.youtube.model.Channel;
+import com.google.common.collect.Lists;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChannelMetadataService {
+
+    private final ChannelSubscriptionRepository channelRepository;
+    private final YouTube youtubeClient;
+
+    @Value("${youtube.api.key}")
+    private String apiKey;
+
+    // 서비스 시작 시 최초 1회 실행
+    @PostConstruct
+    public void initialMetadataUpdate() {
+        log.info("Triggering initial channel metadata update on application startup...");
+        updateAllChannelMetadata();
+    }
+
+    /**
+     * 매주 일요일 새벽 3시에 실행되는 스케줄러
+     * 모든 유튜브 채널의 최신 메타데이터(이름, 썸네일, 구독자 수)를 갱신
+     */
+    @Scheduled(cron = "0 0 3 * * SUN") // 매주 일요일 새벽 3시에 실행
+    @Transactional
+    public void updateAllChannelMetadata() {
+        log.info("Starting weekly channel metadata update job...");
+
+        // 1. DB에서 'YOUTUBE' 소스인 모든 채널을 조회
+        List<ChannelSubscription> allYoutubeChannels = channelRepository.findBySource("YOUTUBE");
+        if (allYoutubeChannels.isEmpty()) {
+            log.info("No YouTube channels found to update. Job finished.");
+            return;
+        }
+
+        // 2. API 할당량을 아끼기 위해 50개씩 묶어서 처리
+        List<List<ChannelSubscription>> batches = Lists.partition(allYoutubeChannels, 50);
+        int updatedCount = 0;
+
+        for (List<ChannelSubscription> batch : batches) {
+            try {
+                // 3. 현재 배치의 채널 ID 목록을 추출
+                List<String> channelIdList = batch.stream()
+                        .map(ChannelSubscription::getChannelId)
+                        .collect(Collectors.toList());
+
+                String commaSeparatedIds = String.join(",", channelIdList);
+
+                // 4. YouTube Data API를 한번만 호출하여 50개 채널의 정보를 모두 조회
+                List<Channel> apiResult = youtubeClient.channels()
+                        .list("snippet,statistics")
+                        .setId(commaSeparatedIds)
+                        .setKey(apiKey)
+                        .execute()
+                        .getItems();
+
+                // 5. 결과를 ID 기준으로 빠르게 찾을 수 있도록 Map으로 변환
+                Map<String, Channel> apiResultMap = apiResult.stream()
+                        .collect(Collectors.toMap(Channel::getId, Function.identity()));
+
+                List<ChannelSubscription> channelsToUpdate = new ArrayList<>();
+
+                // 6. DB 데이터와 API 데이터를 비교하여 변경된 내용이 있거나, 기존 정보가 누락된 경우 업데이트
+                for (ChannelSubscription dbChannel : batch) {
+                    Channel apiChannel = apiResultMap.get(dbChannel.getChannelId());
+                    if (apiChannel == null) continue; // API 결과에 없는 채널은 건너뛰기
+
+                    boolean isChanged = false;
+
+                    // 이름(title) 비교 및 업데이트
+                    String newName = apiChannel.getSnippet().getTitle();
+                    if (!Objects.equals(dbChannel.getYoutubeName(), newName)) {
+                        dbChannel.setYoutubeName(newName);
+                        isChanged = true;
+                    }
+
+                    // 썸네일 비교 및 업데이트 (누락된 경우 채워넣기)
+                    String newThumbnail = apiChannel.getSnippet().getThumbnails().getHigh().getUrl();
+                    if (!Objects.equals(dbChannel.getChannelThumbnailUrl(), newThumbnail)) {
+                        dbChannel.setChannelThumbnailUrl(newThumbnail);
+                        isChanged = true;
+                    }
+
+                    // 구독자 수 비교 및 업데이트 (누락된 경우 채워넣기)
+                    Long newSubsCount = apiChannel.getStatistics().getSubscriberCount().longValue();
+                    if (!Objects.equals(dbChannel.getSubscriberCount(), newSubsCount)) {
+                        dbChannel.setSubscriberCount(newSubsCount);
+                        isChanged = true;
+                    }
+
+                    if (isChanged) {
+                        channelsToUpdate.add(dbChannel);
+                    }
+                }
+
+                // 7. 변경된 채널 정보들을 DB에 일괄 저장
+                if (!channelsToUpdate.isEmpty()) {
+                    channelRepository.saveAll(channelsToUpdate);
+                    updatedCount += channelsToUpdate.size();
+                    log.info("Updated metadata for {} channels in this batch.", channelsToUpdate.size());
+                }
+
+            } catch (Exception e) {
+                log.error("Failed to update channel metadata batch.", e);
+            }
+        }
+        log.info("Finished weekly channel metadata update job. Total updated channels: {}", updatedCount);
+    }
+}

--- a/news-youtube-service/src/main/java/com/example/devnote/news_youtube_service/service/YouTubeChannelInitializer.java
+++ b/news-youtube-service/src/main/java/com/example/devnote/news_youtube_service/service/YouTubeChannelInitializer.java
@@ -1,0 +1,57 @@
+package com.example.devnote.news_youtube_service.service;
+
+import com.example.devnote.news_youtube_service.config.YouTubeProperties;
+import com.example.devnote.news_youtube_service.entity.ChannelSubscription;
+import com.example.devnote.news_youtube_service.repository.ChannelSubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class YouTubeChannelInitializer implements CommandLineRunner {
+
+    private final ChannelSubscriptionRepository channelSubscriptionRepository;
+    private final YouTubeProperties youTubeProperties;
+    private final YouTubeFetchService youTubeFetchService;
+
+    @Override
+    @Transactional
+    public void run(String... args) throws Exception {
+        log.info("Checking for YouTube channels in the database...");
+        int newChannelsCount = 0;
+
+        // yml에 정의된 모든 채널에 대해 반복
+        for (YouTubeProperties.Channel channelProp : youTubeProperties.getChannels()) {
+
+            // 이 channelId로 DB에 이미 존재하는지 확인
+            if (channelSubscriptionRepository.findByChannelId(channelProp.getChannelId()).isEmpty()) {
+
+                // 존재하지 않을 경우에만 새로 생성하여 저장
+                ChannelSubscription newChannel = ChannelSubscription.builder()
+                        .youtubeName(channelProp.getName())
+                        .channelId(channelProp.getChannelId())
+                        .source("YOUTUBE")
+                        .initialLoaded(false)
+                        .build();
+
+                channelSubscriptionRepository.save(newChannel);
+                newChannelsCount++;
+                log.info("Added new YouTube channel to DB: {}", channelProp.getName());
+            }
+        }
+
+        log.info("Triggering initial YouTube data fetch...");
+        youTubeFetchService.fetchAndPublishYoutube();
+        log.info("Initial YouTube data fetch finished.");
+
+        if (newChannelsCount > 0) {
+            log.info("Successfully initialized {} new YouTube channels.", newChannelsCount);
+        } else {
+            log.info("All YouTube channels from yml already exist in the database. Skipping initialization.");
+        }
+    }
+}


### PR DESCRIPTION
#### 1. YAML 기반 유튜브 채널 관리로 전환
- **(제거)** 기존의 불명확한 키워드 검색(`youtube.categories`) 방식을 완전히 제거했습니다.
- **(추가)** `application.yml`에 `youtube.channels` 목록을 직접 정의하여, 수집할 채널을 명확하게 중앙에서 관리하도록 변경했습니다.
- **(추가)** 서비스 시작 시 `YouTubeChannelInitializer`가 `yml` 파일을 읽어 DB에 없는 채널을 자동으로 등록합니다.

#### 2. 채널 메타데이터 주기적 업데이트 기능 추가
- **(추가)** `ChannelMetadataService`를 신설하여 채널 정보 관리 로직을 분리했습니다.
- **(추가)** 매주 일요일 새벽 3시에 스케줄러(`@Scheduled`)가 동작하여 DB에 저장된 모든 유튜브 채널의 최신 정보를 API를 통해 가져옵니다.
  - 채널명, 썸네일, 구독자 수가 변경되었을 경우 DB를 업데이트합니다.
  - 과거 API 호출 실패 등으로 누락되었던 정보를 다시 채워 넣습니다.
- **(추가)** 서비스 시작 시 `@PostConstruct`를 통해 최초 1회 즉시 실행하여, 시작과 동시에 모든 채널의 메타데이터를 동기화합니다.
- **(개선)** API 할당량 소모를 최소화하기 위해, 최대 50개의 채널 ID를 묶어 한 번의 API 호출로 처리하도록 **배치(Batch)** 로직을 구현했습니다.
