### PR TITLE
fix: 마이페이지 찜/댓글 목록 페이지네이션 적용

### DIFF
--- a/user-service/src/main/java/com/example/devnote/controller/ProfileController.java
+++ b/user-service/src/main/java/com/example/devnote/controller/ProfileController.java
@@ -5,6 +5,8 @@ import com.example.devnote.entity.User;
 import com.example.devnote.repository.UserRepository;
 import com.example.devnote.service.UserProfileService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -32,10 +34,16 @@ public class ProfileController {
         );
     }
 
-    /** 프로필 페이지 정보 반환 (찜 영상, 뉴스, 채널 / 작성한 댓글 목록) */
+    /**
+     * 프로필 페이지 정보 반환 (찜 영상, 뉴스, 채널 / 작성한 댓글 목록)
+     * 각 목록에 페이지네이션을 적용
+     * @param pageable 클라이언트에서 전달하는 페이지 정보 (예: ?page=0&size=10)
+     */
     @GetMapping("/dashboard")
-    public ResponseEntity<ApiResponseDto<DashboardDto>> getDashboard() {
-        DashboardDto dto = profileService.getDashboard();
+    public ResponseEntity<ApiResponseDto<DashboardDto>> getDashboard(
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        DashboardDto dto = profileService.getDashboard(pageable);
 
         return ResponseEntity.ok(
                 ApiResponseDto.<DashboardDto> builder()
@@ -77,7 +85,7 @@ public class ProfileController {
         );
     }
 
-    /** 현재 로그인한 사용자의 회원 탈퇴를 처리 */
+    /** 현재 로그인된 사용자의 회원 탈퇴를 처리 */
     @DeleteMapping("/me")
     public ResponseEntity<ApiResponseDto<Void>> withdraw() {
         profileService.withdrawCurrentUser();

--- a/user-service/src/main/java/com/example/devnote/dto/DashboardDto.java
+++ b/user-service/src/main/java/com/example/devnote/dto/DashboardDto.java
@@ -4,8 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
 
 /**
  * 대시보드
@@ -20,16 +19,16 @@ import java.util.List;
 @Builder
 public class DashboardDto {
     /** 찜한 YouTube 영상들 */
-    private List<ContentDto> favoriteVideos;
+    private Page<ContentDto> favoriteVideos;
 
     /** 찜한 News 콘텐츠들 */
-    private List<ContentDto> favoriteNews;
+    private Page<ContentDto> favoriteNews;
 
     /** 찜한 채널들 */
-    private List<ChannelSubscriptionDto> favoriteChannels;
+    private Page<ChannelSubscriptionDto> favoriteChannels;
 
     /** 작성한 댓글들 */
-    private List<CommentResponseDto> comments;
+    private Page<CommentResponseDto> comments;
 
     /** 활동 점수 */
     private Integer activityScore;

--- a/user-service/src/main/java/com/example/devnote/repository/CommentRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/CommentRepository.java
@@ -16,6 +16,7 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
     List<CommentEntity> findByContentIdOrderByCreatedAtAsc(Long contentId);
     List<CommentEntity> findByParentIdOrderByCreatedAtAsc(Long parentId);
     List<CommentEntity> findByUserIdOrderByCreatedAtDesc(Long userId);
+    Page<CommentEntity> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     /** 특정 댓글의 자식 존재 여부 */
     boolean existsByParentId(Long parentId);


### PR DESCRIPTION
 - `GET /api/v1/users/dashboard` API가 `Pageable` 파라미터를 받도록 수정
 - `DashboardDto` 내부의 목록 필드 타입을 `List`에서 `Page` 객체로 변경하여 페이지네이션 정보(총 개수, 총 페이지 등)를 포함하도록 함
 - `UserProfileService`에서 각 목록(찜한 영상, 뉴스, 채널, 작성 댓글)을 페이지 단위로 처리하여 반환하는 로직 구현
 - `CommentRepository`에 페이지네이션 지원을 위한 쿼리 메서드 추가