### PR TITLE
fix: 마이페이지 찜 목록 정렬 기준을 최신순으로 수정

### DIFF
--- a/user-service/src/main/java/com/example/devnote/dto/ChannelSubscriptionDto.java
+++ b/user-service/src/main/java/com/example/devnote/dto/ChannelSubscriptionDto.java
@@ -33,4 +33,7 @@ public class ChannelSubscriptionDto {
 
     /** 찜 수 */
     private Long favoriteCount;
+
+    /** 소스 구분 ("YOUTUBE" 또는 "NEWS")*/
+    private String source;
 }

--- a/user-service/src/main/java/com/example/devnote/repository/FavoriteChannelRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/FavoriteChannelRepository.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 public interface FavoriteChannelRepository extends JpaRepository<FavoriteChannel, Long> {
     Optional<FavoriteChannel> findByUserIdAndChannelSubscriptionId(Long userId, Long chSubId);
     List<FavoriteChannel> findByUserId(Long userId);
+    List<FavoriteChannel> findByUserIdOrderByCreatedAtDesc(Long userId);
     void deleteByChannelSubscriptionId(Long channelSubscriptionId);
     /**
      * 가장 많이 찜한 채널 ID와 찜 수를 페이지네이션하여 조회

--- a/user-service/src/main/java/com/example/devnote/repository/FavoriteContentRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/FavoriteContentRepository.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 public interface FavoriteContentRepository extends JpaRepository<FavoriteContent, Long> {
     Optional<FavoriteContent> findByUserIdAndContentId(Long userId, Long contentId);
     List<FavoriteContent> findByUserId(Long userId);
+    List<FavoriteContent> findByUserIdOrderByCreatedAtDesc(Long userId);
     void deleteByContentId(Long contentId);
     /**
      * 가장 많이 찜한 콘텐츠 ID와 찜 수를 페이지네이션하여 조회

--- a/user-service/src/main/java/com/example/devnote/service/UserProfileService.java
+++ b/user-service/src/main/java/com/example/devnote/service/UserProfileService.java
@@ -128,7 +128,7 @@ public class UserProfileService {
         Long userId = currentUser.getId();
 
         // 1. 찜한 콘텐츠 처리 (영상/뉴스)
-        List<Long> contentIds = favContentRepo.findByUserId(userId)
+        List<Long> contentIds = favContentRepo.findByUserIdOrderByCreatedAtDesc(userId)
                 .stream()
                 .map(FavoriteContent::getContentId)
                 .toList();
@@ -149,7 +149,7 @@ public class UserProfileService {
         Page<ContentDto> favoriteNewsPage = toPage(favoriteNewsList, pageable);
 
         // 2. 찜한 채널 처리
-        List<ChannelSubscriptionDto> favoriteChannelsList = favChannelRepo.findByUserId(userId)
+        List<ChannelSubscriptionDto> favoriteChannelsList = favChannelRepo.findByUserIdOrderByCreatedAtDesc(userId)
                 .stream()
                 .map(fav -> fetchChannelDetails(fav.getChannelSubscriptionId()))
                 .filter(Objects::nonNull)


### PR DESCRIPTION
- `FavoriteContentRepository`와 `FavoriteChannelRepository`의 조회 메서드에 `OrderByCreatedAtDesc`를 추가하여 정렬 기준을 명시했습니다.