### PR TITLE
feat: 랭킹 기능 개선 (콘텐츠 TOP 100 제한 및 채널 랭킹 분리)

### DIFF
--- a/stats-service/src/main/java/com/example/devnote/stats_service/controller/RankingController.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/controller/RankingController.java
@@ -29,7 +29,7 @@ public class RankingController {
     private final StringRedisTemplate redisTemplate;
 
     /**
-     * 가장 많이 찜한 콘텐츠 TOP 50 (페이지당 10개)
+     * 가장 많이 찜한 콘텐츠 TOP 100 (페이지당 10개)
      */
     @GetMapping("/content-favorites")
     public ResponseEntity<ApiResponseDto<PageResponseDto<RankedContentDto>>> getTopFavoritedContents(
@@ -47,7 +47,7 @@ public class RankingController {
     }
 
     /**
-     * 가장 댓글이 많은 콘텐츠 TOP 50 (페이지당 10개)
+     * 가장 댓글이 많은 콘텐츠 TOP 100 (페이지당 10개)
      */
     @GetMapping("/content-comments")
     public ResponseEntity<ApiResponseDto<PageResponseDto<RankedContentDto>>> getTopCommentedContents(
@@ -65,14 +65,14 @@ public class RankingController {
     }
 
     /**
-     * 가장 많이 찜한 채널 TOP 10
+     * 가장 많이 찜한 채널을 유튜브/뉴스 TOP 10으로 나눠 조회
      */
     @GetMapping("/channel-favorites")
-    public ResponseEntity<ApiResponseDto<List<RankedChannelDto>>> getTopFavoritedChannels() {
-        List<RankedChannelDto> data = rankingService.getTopFavoritedChannels();
+    public ResponseEntity<ApiResponseDto<RankedChannelsDto>> getTopFavoritedChannels() {
+        RankedChannelsDto data = rankingService.getTopFavoritedChannelsBySource();
         return ResponseEntity.ok(
-                ApiResponseDto.<List<RankedChannelDto>>builder()
-                        .message("Top 10 favorited channels")
+                ApiResponseDto.<RankedChannelsDto>builder()
+                        .message("Top 10 favorited channels by source")
                         .statusCode(200)
                         .data(data)
                         .build()

--- a/stats-service/src/main/java/com/example/devnote/stats_service/dto/RankedChannelsDto.java
+++ b/stats-service/src/main/java/com/example/devnote/stats_service/dto/RankedChannelsDto.java
@@ -1,0 +1,20 @@
+package com.example.devnote.stats_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 유튜브/뉴스 채널 랭킹을 함께 담는 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RankedChannelsDto {
+    private List<RankedChannelDto> youtube;
+    private List<RankedChannelDto> news;
+}

--- a/user-service/src/main/java/com/example/devnote/controller/InternalRankingController.java
+++ b/user-service/src/main/java/com/example/devnote/controller/InternalRankingController.java
@@ -3,6 +3,7 @@ package com.example.devnote.controller;
 import com.example.devnote.dto.RankedChannelIdDto;
 import com.example.devnote.dto.RankedContentIdDto;
 import com.example.devnote.dto.RankedUserDto;
+import com.example.devnote.repository.FavoriteChannelRepository;
 import com.example.devnote.service.RankingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,6 +25,7 @@ import java.util.List;
 public class InternalRankingController {
 
     private final RankingService rankingService;
+    private final FavoriteChannelRepository favoriteChannelRepository;
 
     /**
      * 가장 많이 찜한 콘텐츠 ID 목록
@@ -50,12 +52,13 @@ public class InternalRankingController {
     }
 
     /**
-     * 가장 많이 찜한 채널 ID 목록
+     * 가장 많이 찜한 채널 ID 목록을 source를 기준으로 조회
      */
     @GetMapping("/channel-favorites")
-    public ResponseEntity<List<RankedChannelIdDto>> getTopFavoritedChannels() {
-        // 상위 10개만 조회
-        List<RankedChannelIdDto> result = rankingService.getTopFavoritedChannels(PageRequest.of(0, 10));
+    public ResponseEntity<List<RankedChannelIdDto>> getTopFavoritedChannels(
+            @RequestParam("source") String source
+    ) {
+        List<RankedChannelIdDto> result = rankingService.getTopFavoritedChannelsBySource(source);
         return ResponseEntity.ok(result);
     }
 

--- a/user-service/src/main/java/com/example/devnote/entity/FavoriteChannel.java
+++ b/user-service/src/main/java/com/example/devnote/entity/FavoriteChannel.java
@@ -23,6 +23,9 @@ public class FavoriteChannel {
     @Column(name = "channel_subscription_id", nullable = false)
     private Long channelSubscriptionId;
 
+    @Column(name = "source", length = 20)
+    private String source;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 

--- a/user-service/src/main/java/com/example/devnote/repository/FavoriteChannelRepository.java
+++ b/user-service/src/main/java/com/example/devnote/repository/FavoriteChannelRepository.java
@@ -2,6 +2,7 @@ package com.example.devnote.repository;
 
 import com.example.devnote.dto.RankedChannelIdDto;
 import com.example.devnote.entity.FavoriteChannel;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -16,13 +17,14 @@ public interface FavoriteChannelRepository extends JpaRepository<FavoriteChannel
     List<FavoriteChannel> findByUserIdOrderByCreatedAtDesc(Long userId);
     void deleteByChannelSubscriptionId(Long channelSubscriptionId);
     /**
-     * 가장 많이 찜한 채널 ID와 찜 수를 페이지네이션하여 조회
+     * 특정 source에서 가장 많이 찜한 채널 ID와 찜 수를 TOP 10 조회
      */
     @Query("SELECT new com.example.devnote.dto.RankedChannelIdDto(fc.channelSubscriptionId, COUNT(fc.id)) " +
             "FROM FavoriteChannel fc " +
+            "WHERE fc.source = :source " +
             "GROUP BY fc.channelSubscriptionId " +
             "ORDER BY COUNT(fc.id) DESC, fc.channelSubscriptionId ASC")
-    List<RankedChannelIdDto> findTopFavoritedChannelIds(Pageable pageable);
+    List<RankedChannelIdDto> findTop10FavoritedChannelIdsBySource(@Param("source") String source, Pageable pageable);
 
     /**
      * 특정 사용자가 찜한 채널/언론사의 총 개수를 조회


### PR DESCRIPTION
1.  **콘텐츠 랭킹 TOP 100 제한 적용**
    - 기존에 전체 콘텐츠를 대상으로 하던 랭킹(찜, 댓글)을 상위 100개로 제한.
    - `user-service`에서 DB 조회 시 100개만 가져온 후, 그 안에서 페이지네이션을 적용하도록 수정하여 API 응답 범위를 명확히 함.

2.  **찜한 채널 랭킹 소스별 분리**
    - 기존의 통합 채널 랭킹을 '유튜브 채널 TOP 10'과 '뉴스 채널 TOP 10'으로 분리.
    - `user-service`의 `FavoriteChannel` 엔티티에 `source` 필드를 추가하고, 찜 등록 시 `source`를 함께 저장하도록 변경.
    - `stats-service`는 `user-service`의 내부 API를 소스별로 호출하여 두 개의 분리된 랭킹을 최종적으로 조합함.